### PR TITLE
Flex/Graphql Updates

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -24,6 +24,7 @@
     "bootstrap": "^5.0.0-beta3",
     "classnames": "^2.3.1",
     "dayjs": "^1.10.4",
+    "isomorphic-unfetch": "^3.1.0",
     "next": "^10.1.3",
     "next-seo": "^4.23.0",
     "react": "^17.0.2",

--- a/website/src/lib/archive.js
+++ b/website/src/lib/archive.js
@@ -1,10 +1,10 @@
 const {
-  getPost,
-  getTags,
+  getContent,
+  //getTags,
   getCategories,
-  getPostsByTag,
-  getPostsByCategory,
-  getAllPostsWithSlug,
+  //getPostsByTag,
+  //getPostsByCategory,
+  getAllContentWithSlug,
 } = require('./wordpress');
 
 const POSTS_PER_PAGE = 2;
@@ -25,14 +25,14 @@ export async function staticPathGenerator(type = 'post_type') {
 
     if (type === 'category' || type === 'tag') {
       // Taxonomy Archive
-      let allTaxonomyResults;
+      let allTaxonomyResults = { edges: [] };
 
       // This could support custom taxonomies or authors if needed
       if (type === 'category') {
         allTaxonomyResults = await getCategories();
-      } else if (type === 'tag') {
+      } /*else if (type === 'tag') {
         allTaxonomyResults = await getTags();
-      }
+      }*/
 
       const taxonomyResults = allTaxonomyResults.edges;
 
@@ -40,14 +40,14 @@ export async function staticPathGenerator(type = 'post_type') {
         const slug = taxonomyResult.node.slug;
         paths.push({ params: { slug: [slug] } }); // Index Page
 
-        let allPosts;
+        let allPosts = { edges: [] };
 
         // This could support custom taxonomies or authors if needed
-        if (type === 'category') {
+        /*if (type === 'category') {
           allPosts = await getPostsByCategory(slug);
         } else if (type === 'tag') {
           allPosts = await getPostsByTag(slug);
-        }
+        }*/
 
         const posts = allPosts.edges;
 
@@ -62,9 +62,9 @@ export async function staticPathGenerator(type = 'post_type') {
       }
     } else {
       // Post type archive
-      const allPosts = await getAllPostsWithSlug();
+      const allPosts = await getAllContentWithSlug();
       paths.push({ params: { slug: [] } }); // Index Page
-      const posts = allPosts.edges;
+      const posts = allPosts.edges || [];
 
       // Generate Pagination Paths
       for (
@@ -127,10 +127,10 @@ export async function staticPropHelper(
         };
       }
 
-      let allPosts;
+      let allPosts = { edges: [] };
       const posts = [];
 
-      if (type === 'category') {
+      /*if (type === 'category') {
         allPosts = await getPostsByCategory(
           staticPropsContext.params.slug[0],
         );
@@ -140,10 +140,10 @@ export async function staticPropHelper(
         );
       } else {
         allPosts = await getAllPostsWithSlug();
-      }
+      }*/
 
       // Get the zero-indexed paginator index (remember URL is indexed by 1)
-      console.log(staticPropsContext.params.slug);
+      //console.log(staticPropsContext.params.slug);
       const page =
         (staticPropsContext.params.slug &&
         staticPropsContext.params.slug[paginatorIndex]
@@ -158,8 +158,8 @@ export async function staticPropHelper(
       // Generate Post Paths
       for (let i = 0; i < filteredPosts.length; i++) {
         const slug = filteredPosts[i].node.slug;
-        const { postBy } = await getPost(slug);
-        posts.push(postBy);
+        const { post } = await getContent(slug);
+        posts.push(post);
       }
 
       return {

--- a/website/src/lib/wordpress.js
+++ b/website/src/lib/wordpress.js
@@ -10,10 +10,6 @@ async function fetchAPI(query, { variables } = {}) {
     ] = `Bearer ${process.env.WORDPRESS_AUTH_REFRESH_TOKEN}`;
   }
 
-  console.log('- - - - -');
-  console.log(query);
-  console.log('- - - - -');
-
   const res = await fetch(WORDPRESS_API_URL, {
     method: 'POST',
     headers,

--- a/website/src/lib/wordpress.js
+++ b/website/src/lib/wordpress.js
@@ -139,14 +139,20 @@ function generateFlex(type) {
           ${fragmentSectionOptions}
         }
         ... on ${type}_Acfflex_FlexContent_Hero {
+          fieldGroupName
           heroHeading
           heroSubheading
           heroImage {
             sourceUrl
+            mediaDetails {
+              width
+              height
+            }
           }
           ${fragmentSectionOptions}
         }
         ... on ${type}_Acfflex_FlexContent_Blockquote {
+          fieldGroupName
           blockquote
           quoteAttribution
           ${fragmentSectionOptions}

--- a/website/src/lib/wordpress.js
+++ b/website/src/lib/wordpress.js
@@ -10,6 +10,10 @@ async function fetchAPI(query, { variables } = {}) {
     ] = `Bearer ${process.env.WORDPRESS_AUTH_REFRESH_TOKEN}`;
   }
 
+  console.log('- - - - -');
+  console.log(query);
+  console.log('- - - - -');
+
   const res = await fetch(WORDPRESS_API_URL, {
     method: 'POST',
     headers,
@@ -80,49 +84,6 @@ let fragmentSectionOptions = /* GraphQL */ `
   sectionSlug
 `;
 
-let fragmentHero = /* GraphQL */ `
-  acfHero {
-    fieldGroupName
-    heroButton {
-      target
-      title
-      url
-    }
-    heroCta
-    heroHeading
-    heroImage {
-      sourceUrl(size: HERO)
-    }
-    heroIntro
-    heroPosts {
-      ... on Post {
-        title
-        uri
-      }
-      ... on Page {
-        title
-        uri
-      }
-      ... on CaseStudy {
-        title
-        uri
-      }
-      ... on NewsPost {
-        title
-        uri
-      }
-      ... on ResourcePost {
-        title
-        uri
-      }
-    }
-    heroPrefix
-    heroStyle
-    heroSubhead
-    hideBreadcrumbs
-  }
-`;
-
 let fragmentCategories = /* GraphQL */ `
   categories {
     nodes {
@@ -153,7 +114,7 @@ export async function getPreviewPost(id, idType = 'DATABASE_ID') {
 /**
  * get all paths. used for static generation
  */
- export async function getAllContentWithSlug() {
+export async function getAllContentWithSlug() {
   const data = await fetchAPI(`
     query AllContent {
       contentNodes {
@@ -166,7 +127,6 @@ export async function getPreviewPost(id, idType = 'DATABASE_ID') {
   return data?.contentNodes;
 }
 
-
 function generateFlex(type) {
   let fragmentFlex = /* GraphQL */ `
     acfFlex {
@@ -178,44 +138,17 @@ function generateFlex(type) {
           wysiwygContent
           ${fragmentSectionOptions}
         }
-        ... on ${type}_Acfflex_FlexContent_Form {
-          fieldGroupName
-          heading
-          content
-          formHeading
-          formSubhead
-          formPosition
-          formFields
-          formInboundLead
-          formDownloadContent
-          formButton
-          formUrl
-          formRedirect {
-            url
+        ... on ${type}_Acfflex_FlexContent_Hero {
+          heroHeading
+          heroSubheading
+          heroImage {
+            sourceUrl
           }
           ${fragmentSectionOptions}
         }
-        ... on ${type}_Acfflex_FlexContent_Media {
-          fieldGroupName
-          youtubeUrl
-          variant
-          width
-          backgroundVideo {
-            mediaItemUrl
-            mediaDetails {
-              width
-              height
-            }
-          }
-          image {
-            altText
-            mediaDetails {
-              width
-              height
-            }
-            sourceUrl(size: _1600_WIDE)
-            mediaItemUrl
-          }
+        ... on ${type}_Acfflex_FlexContent_Blockquote {
+          blockquote
+          quoteAttribution
           ${fragmentSectionOptions}
         }
       }
@@ -283,16 +216,12 @@ export async function getContent(slug, preview, previewData) {
           isFrontPage
           content
           ${generateFlex('Page')}
-          ${fragmentHero}
           ${fragmentSEO}
-          ${fragmentPageOptions}
         }
         ... on Post {
           content
           ${generateFlex('Post')}
-          ${fragmentHero}
           ${fragmentSEO}
-          ${fragmentPageOptions}
         }
       }
     }

--- a/website/src/lib/wordpress.js
+++ b/website/src/lib/wordpress.js
@@ -1,3 +1,4 @@
+import fetch from 'isomorphic-unfetch';
 import { WORDPRESS_API_URL } from 'lib/constants';
 
 async function fetchAPI(query, { variables } = {}) {
@@ -31,8 +32,12 @@ async function fetchAPI(query, { variables } = {}) {
  * Reusable Fragments
  */
 
-let fragmentSEO = `
+let fragmentSEO = /* GraphQL */ `
   seo {
+    breadcrumbs {
+      text
+      url
+    }
     canonical
     metaDesc
     metaRobotsNofollow
@@ -59,6 +64,75 @@ let fragmentSEO = `
   }
 `;
 
+let fragmentPageOptions = /* GraphQL */ `
+  acfPageOptions {
+    footerHideNav
+    footerHideSignup
+    footerStyle
+    headerHideNav
+  }
+`;
+
+let fragmentSectionOptions = /* GraphQL */ `
+  backgroundColor
+  hideSection
+  sectionClasses
+  sectionSlug
+`;
+
+let fragmentHero = /* GraphQL */ `
+  acfHero {
+    fieldGroupName
+    heroButton {
+      target
+      title
+      url
+    }
+    heroCta
+    heroHeading
+    heroImage {
+      sourceUrl(size: HERO)
+    }
+    heroIntro
+    heroPosts {
+      ... on Post {
+        title
+        uri
+      }
+      ... on Page {
+        title
+        uri
+      }
+      ... on CaseStudy {
+        title
+        uri
+      }
+      ... on NewsPost {
+        title
+        uri
+      }
+      ... on ResourcePost {
+        title
+        uri
+      }
+    }
+    heroPrefix
+    heroStyle
+    heroSubhead
+    hideBreadcrumbs
+  }
+`;
+
+let fragmentCategories = /* GraphQL */ `
+  categories {
+    nodes {
+      name
+      slug
+      uri
+    }
+  }
+`;
+
 export async function getPreviewPost(id, idType = 'DATABASE_ID') {
   const data = await fetchAPI(
     `
@@ -76,191 +150,84 @@ export async function getPreviewPost(id, idType = 'DATABASE_ID') {
   return data.post;
 }
 
-export async function getAllPostsWithSlug() {
+/**
+ * get all paths. used for static generation
+ */
+ export async function getAllContentWithSlug() {
   const data = await fetchAPI(`
-    {
-      posts(first: 10000) {
-        edges {
-          node {
-            slug
-          }
+    query AllContent {
+      contentNodes {
+        nodes {
+          uri
         }
       }
     }
   `);
-  return data?.posts;
+  return data?.contentNodes;
 }
 
-export async function getAllPagesWithSlug() {
-  const data = await fetchAPI(`
-    {
-      pages {
-        edges {
-          node {
-            slug
-          }
+
+function generateFlex(type) {
+  let fragmentFlex = /* GraphQL */ `
+    acfFlex {
+      fieldGroupName
+      flexContent {
+        ... on ${type}_Acfflex_FlexContent_WysiwygContent {
+          fieldGroupName
+          sectionHeading
+          wysiwygContent
+          ${fragmentSectionOptions}
         }
-      }
-    }
-  `);
-  return data?.pages;
-}
-
-export async function getPageWithSlug() {
-  const data = await fetchAPI(`
-    {
-      posts(first: 10000) {
-        edges {
-          node {
-            slug
+        ... on ${type}_Acfflex_FlexContent_Form {
+          fieldGroupName
+          heading
+          content
+          formHeading
+          formSubhead
+          formPosition
+          formFields
+          formInboundLead
+          formDownloadContent
+          formButton
+          formUrl
+          formRedirect {
+            url
           }
+          ${fragmentSectionOptions}
         }
-      }
-    }
-  `);
-  return data?.posts;
-}
-
-export async function getPosts(preview) {
-  const data = await fetchAPI(
-    `
-    query AllPosts {
-      posts(first: 20, where: {orderby: {field: DATE, order: DESC}}) {
-        edges {
-          node {
-            title
-            excerpt
-            slug
-            date
-            featuredImage {
-              node {
-                sourceUrl
-                mediaDetails {
-                  height
-                  width
-                }
-              }
-            }
-            author {
-              node {
-                firstName
-                lastName
-              }
+        ... on ${type}_Acfflex_FlexContent_Media {
+          fieldGroupName
+          youtubeUrl
+          variant
+          width
+          backgroundVideo {
+            mediaItemUrl
+            mediaDetails {
+              width
+              height
             }
           }
-        }
-      }
-    }
-  `,
-    {
-      variables: {
-        onlyEnabled: !preview,
-        preview,
-      },
-    },
-  );
-
-  return data?.posts;
-}
-
-export async function getPostsByCategory(categorySlug) {
-  const data = await fetchAPI(`
-    {
-      posts(first: 10000, where: {categoryName: "${categorySlug}"}) {
-        edges {
-          node {
-            slug
-          }
-        }
-      }
-    }
-  `);
-
-  return data?.posts;
-}
-
-export async function getPostsByTag(tagSlug) {
-  const data = await fetchAPI(`
-    {
-      posts(first: 10000, where: {tag: "${tagSlug}"}) {
-        edges {
-          node {
-            slug
-          }
-        }
-      }
-    }
-  `);
-
-  return data?.posts;
-}
-
-export async function getHeroes() {
-  const data = await fetchAPI(`
-    query AllHeroes {
-      heroes {
-        edges {
-          node {
-            hero {
-              buttonLink
-              buttonText
-              buttonType
-              fieldGroupName
-              headline
-              subhead
-              img {
-                uri
-                link
-                sourceUrl(size: LARGE)
-                altText
-                mediaDetails {
-                  height
-                  width
-                }
-              }
+          image {
+            altText
+            mediaDetails {
+              width
+              height
             }
+            sourceUrl(size: _1600_WIDE)
+            mediaItemUrl
           }
+          ${fragmentSectionOptions}
         }
       }
     }
-  `);
-
-  return data?.heroes;
+  `;
+  return fragmentFlex;
 }
 
-export async function getCategories() {
-  const data = await fetchAPI(`
-    query AllCategories {
-      categories {
-        edges {
-          node {
-            slug
-          }
-        }
-      }
-    }
-  `);
-
-  return data.categories;
-}
-
-export async function getTags() {
-  const data = await fetchAPI(`
-    query AllTags {
-      tags {
-        edges {
-          node {
-            slug
-          }
-        }
-      }
-    }
-  `);
-
-  return data.tags;
-}
-
-export async function getPage(slug, preview, previewData) {
+/**
+ * Get fields for single page regardless of post type.
+ */
+export async function getContent(slug, preview, previewData) {
   const postPreview = preview && previewData?.post;
   // The slug may be the id of an unpublished post
   const isId = Number.isInteger(Number(slug));
@@ -269,85 +236,71 @@ export async function getPage(slug, preview, previewData) {
     : slug === postPreview.slug;
   const isDraft = isSamePost && postPreview?.status === 'draft';
   const isRevision = isSamePost && postPreview?.status === 'publish';
-  let uri = slug;
-  const data = await fetchAPI(
-    `
-    fragment SEOFields on Page {
-      ${fragmentSEO}
-    }
+  // console.log('slug for single', slug);
+  let query = /* GraphQL */ `
+    query GetContent($slug: ID!) {
+      contentNode(id: $slug, idType: URI) {
+        __typename
+        id
+        isPreview
+        link
+        slug
+        uri
 
-    fragment PageFields on Page {
-      title
-      slug
-      content
-      template {
-        templateName
-      }
-      featuredImage {
-        node {
-          sourceUrl
-          mediaDetails {
-            height
-            width
-          }
+        ... on NodeWithTitle {
+          title
         }
-      }
-    }
-
-    fragment FlexFields on Page {
-      acfFlex {
-        fieldGroupName
-        flexContent {
-          ... on Page_Acfflex_FlexContent_Blockquote {
-            backgroundColor
-            blockquote
-            fieldGroupName
-            quoteAttribution
-            hideSection
-            sectionClasses
-            sectionSlug
-          }
-          ... on Page_Acfflex_FlexContent_Hero {
-            backgroundColor
-            fieldGroupName
-            heroHeading
-            heroSubheading
-            heroImage {
+        ... on NodeWithFeaturedImage {
+          featuredImage {
+            node {
+              caption
               sourceUrl
               mediaDetails {
                 height
                 width
               }
             }
-            hideSection
-            sectionClasses
-            sectionSlug
           }
-          ... on Page_Acfflex_FlexContent_WysiwygContent {
-            backgroundColor
-            fieldGroupName
-            hideSection
-            sectionClasses
-            sectionHeading
-            sectionSlug
-            wysiwygContent
+        }
+        ... on NodeWithTemplate {
+          template {
+            __typename
+            templateName
           }
+        }
+        ... on NodeWithAuthor {
+          authorId
+          author {
+            node {
+              id
+              name
+              nicename
+              lastName
+            }
+          }
+        }
+        ... on Page {
+          isFrontPage
+          content
+          ${generateFlex('Page')}
+          ${fragmentHero}
+          ${fragmentSEO}
+          ${fragmentPageOptions}
+        }
+        ... on Post {
+          content
+          ${generateFlex('Post')}
+          ${fragmentHero}
+          ${fragmentSEO}
+          ${fragmentPageOptions}
         }
       }
     }
-    query PageBySlug($uri: String) {
-      pageBy(uri: $uri) {
-        ...PageFields
-        ...FlexFields
-        ...SEOFields
-        content
-      }
-    }
-    `,
-    {
-      variables: { uri },
-    },
-  );
+  `;
+  // console.log('query for getContent', query);
+  const data = await fetchAPI(query, {
+    variables: { slug },
+  });
 
   // Draft posts may not have an slug
   if (isDraft) data.post.slug = postPreview.id;
@@ -359,112 +312,113 @@ export async function getPage(slug, preview, previewData) {
     delete data.post.revisions;
   }
 
-  data.post = data.pageBy;
-
+  // console.log('data', data);
+  data.post = data.contentNode;
   return data;
 }
 
-export async function getPost(slug, preview, previewData) {
-  const postPreview = preview && previewData?.post;
-  // The slug may be the id of an unpublished post
-  const isId = Number.isInteger(Number(slug));
-  const isSamePost = isId
-    ? Number(slug) === postPreview.id
-    : slug === postPreview?.slug;
-  const isDraft = isSamePost && postPreview?.status === 'draft';
-  const isRevision = isSamePost && postPreview?.status === 'publish';
-  const uri = slug;
-  const data = await fetchAPI(
-    `
-    fragment SEOFields on Post {
-      ${fragmentSEO}
-    }
+/**
+ * Get a list of posts for news.
+ */
 
-    fragment PostFields on Post {
-      title
-      slug
-      featuredImage {
-        node {
-          sourceUrl
-          mediaDetails {
-            height
-            width
+export async function getPosts({
+  ids,
+  first = 12,
+  after = null,
+  searchQuery = null,
+  contentTypes = ['POST', 'CASE_STUDIES', 'RESOURCES', 'NEWS'],
+  orderField = 'DATE',
+  orderDirection = 'DESC',
+  taxonomyType = null,
+  taxonomyTerms = null,
+}) {
+  const taxonomyQuery =
+    'taxQuery: {taxArray: { taxonomy: $taxonomyType, terms: $taxonomyTerms, field: SLUG }},';
+
+  const taxonomyParams = `
+      $taxonomyType: TaxonomyEnum!
+      $taxonomyTerms: [String]`;
+
+  let query = /* GraphQL */ `
+    # query GetPosts($first: Int, $contentTypes: Array) {
+    query GetPosts(
+      $ids: [ID]
+      $first: Int
+      $after: String
+      $contentTypes: [ContentTypeEnum!]!
+      $searchQuery: String
+      $orderField: PostObjectsConnectionOrderbyEnum!
+      $orderDirection: OrderEnum!
+      ${taxonomyType && taxonomyTerms ? taxonomyParams : ''}
+    ) {
+      contentNodes(
+        first: $first
+        after: $after
+        where: {
+          ${taxonomyType && taxonomyTerms ? taxonomyQuery : ''}
+          in: $ids,
+          search: $searchQuery,
+          contentTypes: $contentTypes,
+          orderby: {field: $orderField, order: $orderDirection}}
+      ) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          slug
+          uri
+          ... on NodeWithFeaturedImage {
+            featuredImage {
+              node {
+                caption
+                sourceUrl(size: SOCIAL)
+                mediaDetails {
+                  height
+                  width
+                }
+              }
+            }
+          }
+          ... on NodeWithTitle {
+            title
+          }
+          contentType {
+            node {
+              name
+            }
+          }
+          ... on Post {
+            ${fragmentCategories}
           }
         }
       }
     }
-    query PostBySlug($uri: String) {
-      postBy(uri: $uri) {
-        ...PostFields
-        ...SEOFields
-        content
-      }
-    }
-    `,
-    {
-      variables: { uri },
+  `;
+  // console.log('query', query);
+  const data = await fetchAPI(query, {
+    variables: {
+      contentTypes,
+      first,
+      searchQuery,
+      after,
+      ids,
+      orderField,
+      orderDirection,
+      taxonomyType,
+      taxonomyTerms,
     },
-  );
-
-  // Draft posts may not have an slug
-  if (isDraft) data.post.slug = postPreview.id;
-  // Apply a revision (changes in a published post)
-  if (isRevision && data.post.revisions) {
-    const revision = data.post.revisions.edges[0]?.node;
-
-    if (revision) Object.assign(data.post, revision);
-    delete data.post.revisions;
-  }
-
-  data.post = data.pageBy;
+  });
+  // console.log('data', JSON.stringify(data, null, 2));
 
   return data;
 }
 
-export async function getPostAndMorePosts(
-  slug,
-  preview,
-  previewData,
-) {
-  const postPreview = preview && previewData?.post;
-  // The slug may be the id of an unpublished post
-  const isId = Number.isInteger(Number(slug));
-  const isSamePost = isId
-    ? Number(slug) === postPreview.id
-    : slug === postPreview.slug;
-  const isDraft = isSamePost && postPreview?.status === 'draft';
-  const isRevision = isSamePost && postPreview?.status === 'publish';
-  /*eslint-disable */
-  const data = await fetchAPI(
-    `
-    fragment AuthorFields on User {
-      firstName
-      lastName
-      name
-      nicename
-      nickname
-      uri
-      slug
-    }
-    fragment PostFields on Post {
-      title
-      excerpt
-      slug
-      date
-      featuredImage {
-        node {
-          sourceUrl
-          mediaDetails {
-            height
-            width
-          }
-        }
-      }
-      author {
-        node {
-          ...AuthorFields
-        }
-      }
+/** All Taxonomy Terms */
+
+export async function getCategories() {
+  let query = /* GraphQL */ `
+    query AllCategories {
       categories {
         edges {
           node {
@@ -473,73 +427,47 @@ export async function getPostAndMorePosts(
           }
         }
       }
-      tags {
-        edges {
-          node {
-            name
-            slug
-          }
-        }
-      }
     }
-    query PostBySlug($id: ID!, $idType: PostIdType!) {
-      post(id: $id, idType: $idType) {
-        ...PostFields
-        content
-        ${
-          // Only some of the fields of a revision are considered as there are some inconsistencies
-          isRevision
-            ? `
-        revisions(first: 1, where: { orderby: { field: MODIFIED, order: DESC } }) {
-          edges {
-            node {
-              title
-              excerpt
-              content
-              author {
-                ...AuthorFields
-              }
+  `;
+
+  const data = await fetchAPI(query);
+  return data.categories;
+}
+
+/**
+ * Global Props
+ * (Might merge into other queries via fragment)
+ * */
+export async function getGlobalProps() {
+  let query = /* GraphQL */ `
+    fragment Menus on RootQuery {
+      menus {
+        nodes {
+          id
+          databaseId
+          name
+          menuItems {
+            nodes {
+              id
+              label
+              parentId
+              url
+              path
             }
           }
         }
-        `
-            : ''
-        }
-      }
-      posts(first: 3, where: { orderby: { field: DATE, order: DESC } }) {
-        edges {
-          node {
-            ...PostFields
-          }
-        }
       }
     }
-  `,
-    {
-      variables: {
-        id: isDraft ? postPreview.id : slug,
-        idType: isDraft ? 'DATABASE_ID' : 'SLUG',
-      },
-    },
-  );
-  /*eslint-enable */
+    fragment GlobalOptions on RootQuery {
+      themeSettings
+    }
 
-  // Draft posts may not have an slug
-  if (isDraft) data.post.slug = postPreview.id;
-  // Apply a revision (changes in a published post)
-  if (isRevision && data.post.revisions) {
-    const revision = data.post.revisions.edges[0]?.node;
+    query AllGlobals {
+      ...Menus
+      ...GlobalOptions
+    }
+  `;
 
-    if (revision) Object.assign(data.post, revision);
-    delete data.post.revisions;
-  }
-
-  // Filter out the main post
-  data.posts.edges = data.posts.edges.filter(
-    ({ node }) => node.slug !== slug,
-  );
-  // If there are still 3 posts, remove the last one
-  if (data.posts.edges.length > 2) data.posts.edges.pop();
-
+  const data = await fetchAPI(query);
   return data;
 }

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -1,7 +1,7 @@
 import Flex from 'components/flex/Flex';
 import LayoutDefault from 'components/layouts/LayoutDefault';
 import PostBody from 'components/post/PostBody';
-import { getPage, getAllPagesWithSlug } from 'lib/wordpress';
+import { getContent, getAllContentWithSlug } from 'lib/wordpress';
 
 export default function Page({
   post,
@@ -80,7 +80,7 @@ export async function getStaticProps({
     slug += params.slug.join('/');
   }
 
-  const data = await getPage(slug, preview, previewData);
+  const data = await getContent(slug, preview, previewData);
   if (!data?.post?.slug) {
     return {
       notFound: true,
@@ -99,10 +99,12 @@ export async function getStaticProps({
 }
 
 export async function getStaticPaths() {
-  const allPosts = await getAllPagesWithSlug();
+  const allPosts = await getAllContentWithSlug();
+
+  console.log(allPosts);
 
   return {
-    paths: allPosts.edges.map(({ node }) => `/${node.slug}`) || [],
+    paths: allPosts.nodes.map(({ uri }) => uri) || [],
     fallback: 'blocking',
   };
 }

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -102,8 +102,6 @@ export async function getStaticProps({
 export async function getStaticPaths() {
   const allPosts = await getAllContentWithSlug();
 
-  console.log(allPosts);
-
   return {
     paths: allPosts.nodes.map(({ uri }) => uri) || [],
     fallback: 'blocking',

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -81,6 +81,7 @@ export async function getStaticProps({
   }
 
   const data = await getContent(slug, preview, previewData);
+
   if (!data?.post?.slug) {
     return {
       notFound: true,
@@ -90,7 +91,7 @@ export async function getStaticProps({
   return {
     props: {
       preview,
-      post: data.pageBy,
+      post: data.post,
       flexSections: data.post?.acfFlex?.flexContent || null,
       template: data.post?.template?.templateName || null,
     },

--- a/website/src/pages/posts/[[...slug]].js
+++ b/website/src/pages/posts/[[...slug]].js
@@ -2,7 +2,7 @@ import LayoutDefault from 'components/layouts/LayoutDefault';
 import PostArchive from 'components/post/PostArchive';
 
 import { staticPropHelper, staticPathGenerator } from 'lib/archive';
-import { getPost } from 'lib/wordpress';
+import { getContent } from 'lib/wordpress';
 import { useRouter } from 'next/router';
 
 function PostsSinglePage({ post }) {
@@ -65,8 +65,8 @@ export async function getStaticProps(context) {
   // Generate props for Post Single Page
   //
   try {
-    const { postBy } = await getPost(context.params.slug[0]);
-    return { props: { post: postBy } };
+    const { post } = await getContent(context.params.slug[0]);
+    return { props: { post } };
   } catch (error) {
     console.log(error);
   }

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -2375,6 +2375,14 @@ isobject@^2.0.0:
   dependencies:
     isarray "1.0.0"
 
+isomorphic-unfetch@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz#87341d5f4f7b63843d468438128cb087b7c3e98f"
+  integrity sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==
+  dependencies:
+    node-fetch "^2.6.1"
+    unfetch "^4.2.0"
+
 jest-worker@27.0.0-next.5:
   version "27.0.0-next.5"
   resolved "https://registry.yarnpkg.com/jest-worker/-/jest-worker-27.0.0-next.5.tgz#5985ee29b12a4e191f4aae4bb73b97971d86ec28"
@@ -2851,7 +2859,7 @@ next@^10.1.3:
     vm-browserify "1.1.2"
     watchpack "2.1.1"
 
-node-fetch@2.6.1:
+node-fetch@2.6.1, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -4428,6 +4436,11 @@ unbox-primitive@^1.0.0:
     has-bigints "^1.0.1"
     has-symbols "^1.0.2"
     which-boxed-primitive "^1.0.2"
+
+unfetch@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/unfetch/-/unfetch-4.2.0.tgz#7e21b0ef7d363d8d9af0fb929a5555f6ef97a3be"
+  integrity sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==
 
 unified@^9.1.0:
   version "9.2.0"

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -28,6 +28,23 @@
           "ffraenz/private-composer-installer": "^5.0"
         }
       }
+    },
+    {
+      "type": "package",
+      "package": {
+        "name": "wp-graphql/wp-graphql-tax-query",
+        "version": "0.1.0",
+        "type": "wordpress-plugin",
+        "dist": {
+          "type": "zip",
+          "url": "https://github.com/wp-graphql/wp-graphql-tax-query/archive/refs/tags/v0.1.0.zip"
+        },
+        "require": {
+          "composer/installers": "^1.8",
+          "ffraenz/private-composer-installer": "^5.0",
+          "wpackagist-plugin/wp-graphql": "^1.3"
+        }
+      }
     }
   ],
   "require": {
@@ -46,6 +63,7 @@
     "wpackagist-plugin/wordpress-seo": "16.0.2",
     "wpackagist-plugin/wp-graphql": "1.3.3",
     "wp-graphql/wp-graphql-acf": "0.4.0",
+    "wp-graphql/wp-graphql-tax-query": "0.1.0",
     "ashhitch/wp-graphql-yoast-seo": "4.12.0",
     "wpackagist-plugin/safe-svg": "^1.9"
   },

--- a/wordpress/wp-content/themes/headless/acf-json/group_5f4f38e0bff98.json
+++ b/wordpress/wp-content/themes/headless/acf-json/group_5f4f38e0bff98.json
@@ -82,5 +82,7 @@
     "hide_on_screen": "",
     "active": true,
     "description": "",
-    "modified": 1599027719
+    "show_in_graphql": 0,
+    "graphql_field_name": "hero",
+    "modified": 1621356426
 }

--- a/wordpress/wp-content/themes/headless/functions.php
+++ b/wordpress/wp-content/themes/headless/functions.php
@@ -27,13 +27,13 @@ add_action('customize_register', 'bubs_theme_options');
 
 
 // Post Types
-include_once 'setup/post-types/events.php';
-include_once 'setup/post-types/heroes.php';
-include_once 'setup/post-types/members.php';
+//include_once 'setup/post-types/events.php';
+//include_once 'setup/post-types/heroes.php';
+//include_once 'setup/post-types/members.php';
 
 
 // Taxonomies
-include_once 'setup/taxonomies/issue-areas.php';
+//include_once 'setup/taxonomies/issue-areas.php';
 
 
 // WP Helper Functions

--- a/wordpress/wp-content/themes/headless/setup/helpers/wpgraphql.php
+++ b/wordpress/wp-content/themes/headless/setup/helpers/wpgraphql.php
@@ -7,7 +7,7 @@
 // salt generator: https://api.wordpress.org/secret-key/1.1/salt/
 //
 
-// if a public repo, uncomment the next line, and 
+// if a public repo, uncomment the next line, and
 // copy this filter and save in wpgraphql-jwt.php
 // include_once 'wpgraphql-jwt.php';
 
@@ -23,20 +23,25 @@
 // Workaround until this is fixed in a future version:
 // https://github.com/wp-graphql/wp-graphql-acf/issues/76
 
-function expose_acf_to_graphql_only($result, $rule, $screen, $field_group)
-{
-    if (!is_graphql_http_request()) {
-        return $result;
-    }
-
-    // this is the value of mandatory graphql
-    $page_template_acf_groups = [
-        'acfFlex',
-    ];
-    if (in_array($field_group['graphql_field_name'], $page_template_acf_groups) && $screen['post_type'] === 'page') {
-        return true;
-    }
-
+function expose_acf_to_graphql_only($result, $rule, $screen, $field_group) {
+  if ( !is_graphql_http_request() ) {
     return $result;
+  }
+
+  // ACF GraphQL Field Name
+  $page_template_acf_groups = [ 'acfFlex' ];
+
+  // Add other post types here
+  $post_types = [ 'page', 'post' ];
+
+  if (
+    in_array( $field_group['graphql_field_name'], $page_template_acf_groups ) &&
+    in_array( $screen['post_type'], $post_types )
+  ) {
+    return true;
+  }
+
+  return $result;
 }
+
 add_filter('acf/location/rule_match', 'expose_acf_to_graphql_only', 10, 4);


### PR DESCRIPTION
Upstream some of our recent wordpress.js changes in graphql.

* Uses ContentNode more than Post/Page to keep graphql statements more concise. Also keeps CPTs easier to integrate.
* Doubles down on flex modules and adding new flex modules is straightforward