### PR TITLE
Header/Footer menus and options

### DIFF
--- a/website/src/components/Footer.js
+++ b/website/src/components/Footer.js
@@ -10,26 +10,26 @@ import {
   FaTwitter,
   FaYoutube,
 } from 'react-icons/fa';
+import { IoLogoTiktok } from 'react-icons/io5';
 import styles from './Footer.module.scss';
 
 export default function Footer() {
   const globals = useContext(GlobalsContext);
 
   // populate and format menus
+  const footerNav = Array.isArray(globals?.menuFooter?.nodes)
+    ? formatMenu(globals.menuFooter.nodes)
+    : [];
 
-  let footerNav = [];
-  let secondaryNav = [];
-  let socialNav = [];
+  const secondaryNav = Array.isArray(
+    globals?.menuFooterSecondary?.nodes,
+  )
+    ? formatMenu(globals.menuFooterSecondary.nodes)
+    : [];
 
-  if (Array.isArray(globals?.menuFooter?.nodes)) {
-    footerNav = formatMenu(globals.menuFooter.nodes);
-  }
-  if (Array.isArray(globals?.menuFooterSocial?.nodes)) {
-    socialNav = globals.menuFooterSocial.nodes;
-  }
-  if (Array.isArray(globals?.menuFooterSecondary?.nodes)) {
-    secondaryNav = globals.menuFooterSecondary.nodes;
-  }
+  const socialNav = Array.isArray(globals?.menuFooterSocial?.nodes)
+    ? formatMenu(globals.menuFooterSocial.nodes)
+    : [];
 
   let hideSocial = false;
   // let hideSignup = false;
@@ -131,6 +131,9 @@ export default function Footer() {
                     )}
                     {item.path.includes('linkedin.com') && (
                       <FaLinkedinIn />
+                    )}
+                    {item.path.includes('tiktok.com') && (
+                      <IoLogoTiktok />
                     )}
                   </a>
                 </li>

--- a/website/src/components/Footer.js
+++ b/website/src/components/Footer.js
@@ -14,7 +14,6 @@ import styles from './Footer.module.scss';
 
 export default function Footer() {
   const globals = useContext(GlobalsContext);
-  console.log('globals', JSON.stringify(globals, null, 2));
 
   // populate and format menus
 

--- a/website/src/components/Footer.js
+++ b/website/src/components/Footer.js
@@ -14,6 +14,7 @@ import styles from './Footer.module.scss';
 
 export default function Footer() {
   const globals = useContext(GlobalsContext);
+  console.log('globals', JSON.stringify(globals, null, 2));
 
   // populate and format menus
 
@@ -56,8 +57,59 @@ export default function Footer() {
       )}
     >
       <div className="container">
-        {!hideSocial && socialNav.length && (
-          <div className={cx([styles.social, 'row row-cols-12'])}>
+        {!hideNav && footerNav.length > 0 && (
+          <div
+            className={cx([
+              styles.primary,
+              'row row-cols-2 row-cols-lg-auto',
+            ])}
+          >
+            {footerNav.map((item, i) => (
+              <div key={i}>
+                <Link href={item.path}>
+                  <a className={styles.topLevel}>{item.label}</a>
+                </Link>
+                {item.children && item.children.length > 0 && (
+                  <ul className="list-unstyled">
+                    {item.children.map((item, i) => (
+                      <li key={`primary-${i}`}>
+                        <Link href={item.path}>
+                          <a>{item.label}</a>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className={cx([styles.copyright, 'row text-center'])}>
+          <div className="col">
+            {secondaryNav.length > 0 && (
+              <ul className="list-inline mb-0">
+                {secondaryNav.map((item, i) => (
+                  <li className="list-inline-item" key={i}>
+                    <Link href={item.path} prefetch={false}>
+                      <a>{item.label}</a>
+                    </Link>
+                    <span className={styles.divider}>|</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <p>&copy; copyright {new Date().getFullYear()}</p>
+          </div>
+        </div>
+
+        {!hideSocial && socialNav.length > 0 && (
+          <div
+            className={cx([
+              styles.social,
+              'row row-cols-12 text-center',
+            ])}
+          >
             <ul className="list-inline mb-0">
               {socialNav.map((item, i) => (
                 <li className="list-inline-item" key={i}>
@@ -87,56 +139,6 @@ export default function Footer() {
             </ul>
           </div>
         )}
-        {!hideNav && footerNav && (
-          <div
-            className={cx([
-              styles.primary,
-              'row row-cols-2 row-cold-lg-4',
-            ])}
-          >
-            {footerNav.map((item, i) => (
-              <div key={i}>
-                <Link href={item.path} passHref>
-                  <div className={styles.topLevel}>
-                    <a>{item.label}</a>
-                  </div>
-                </Link>
-                {item.children && item.children.length > 0 && (
-                  <ul>
-                    {item.children.map((item, i) => (
-                      <li
-                        key={`primary-${i}`}
-                        className="list-style-none"
-                      >
-                        <Link href={item.path}>
-                          <a>{item.label}</a>
-                        </Link>
-                      </li>
-                    ))}
-                  </ul>
-                )}
-              </div>
-            ))}
-          </div>
-        )}
-
-        <div className={cx([styles.copyright, 'row text-center'])}>
-          <div className="col">
-            {secondaryNav.length && (
-              <ul className="list-inline mb-0">
-                {secondaryNav.map((item, i) => (
-                  <li className="list-inline-item" key={i}>
-                    <Link href={item.path} prefetch={false}>
-                      <a>{item.label}</a>
-                    </Link>
-                    <span className={styles.divider}>|</span>
-                  </li>
-                ))}
-              </ul>
-            )}
-            <p>&copy; copyright {new Date().getFullYear()}</p>
-          </div>
-        </div>
       </div>
     </footer>
   );

--- a/website/src/components/Footer.js
+++ b/website/src/components/Footer.js
@@ -1,13 +1,52 @@
 import cx from 'classnames';
 import GlobalsContext from 'contexts/GlobalsContext';
-import _get from 'lodash/get';
+import formatMenu from 'lib/formatMenu';
 import Link from 'next/link';
 import { useContext } from 'react';
+import {
+  FaFacebookF,
+  FaLinkedinIn,
+  FaInstagram,
+  FaTwitter,
+  FaYoutube,
+} from 'react-icons/fa';
 import styles from './Footer.module.scss';
 
 export default function Footer() {
   const globals = useContext(GlobalsContext);
-  const menus = _get(globals, 'menus.nodes[0].menuItems.nodes', []);
+
+  // populate and format menus
+
+  let footerNav = [];
+  let secondaryNav = [];
+  let socialNav = [];
+
+  if (Array.isArray(globals?.menuFooter?.nodes)) {
+    footerNav = formatMenu(globals.menuFooter.nodes);
+  }
+  if (Array.isArray(globals?.menuFooterSocial?.nodes)) {
+    socialNav = globals.menuFooterSocial.nodes;
+  }
+  if (Array.isArray(globals?.menuFooterSecondary?.nodes)) {
+    secondaryNav = globals.menuFooterSecondary.nodes;
+  }
+
+  let hideSocial = false;
+  // let hideSignup = false;
+  let hideNav = false;
+  // let hideSearch = false;
+
+  if (globals.pageOptions?.footerStyle == 'basic') {
+    hideNav = true;
+    // hideSearch = true;
+    // hideSignup = true;
+    hideSocial = true;
+  } else if (globals.pageOptions?.footerStyle == 'custom') {
+    hideNav = globals.pageOptions?.hideNav;
+    // hideSearch = globals.pageOptions?.hideSearch;
+    // hideSignup = globals.pageOptions?.hideSignup;
+    hideSocial = globals.pageOptions?.hideSocial;
+  }
 
   return (
     <footer
@@ -17,20 +56,85 @@ export default function Footer() {
       )}
     >
       <div className="container">
-        <div className={cx('row', styles.nav)}>
-          <div className="col">
+        {!hideSocial && socialNav.length && (
+          <div className={cx([styles.social, 'row row-cols-12'])}>
             <ul className="list-inline mb-0">
-              {menus.map((item, i) => (
+              {socialNav.map((item, i) => (
                 <li className="list-inline-item" key={i}>
-                  <a href={item.path}>{item.label}</a>
+                  <a
+                    href={item.path}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
+                    {item.path.includes('instagram.com') && (
+                      <FaInstagram />
+                    )}
+                    {item.path.includes('twitter.com') && (
+                      <FaTwitter />
+                    )}
+                    {item.path.includes('youtube.com') && (
+                      <FaYoutube />
+                    )}
+                    {item.path.includes('facebook.com') && (
+                      <FaFacebookF />
+                    )}
+                    {item.path.includes('linkedin.com') && (
+                      <FaLinkedinIn />
+                    )}
+                  </a>
                 </li>
               ))}
             </ul>
           </div>
-        </div>
-        <div className="row">
+        )}
+        {!hideNav && footerNav && (
+          <div
+            className={cx([
+              styles.primary,
+              'row row-cols-2 row-cold-lg-4',
+            ])}
+          >
+            {footerNav.map((item, i) => (
+              <div key={i}>
+                <Link href={item.path} passHref>
+                  <div className={styles.topLevel}>
+                    <a>{item.label}</a>
+                  </div>
+                </Link>
+                {item.children && item.children.length > 0 && (
+                  <ul>
+                    {item.children.map((item, i) => (
+                      <li
+                        key={`primary-${i}`}
+                        className="list-style-none"
+                      >
+                        <Link href={item.path}>
+                          <a>{item.label}</a>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className={cx([styles.copyright, 'row text-center'])}>
           <div className="col">
-            <small>&copy; copyright {new Date().getFullYear()}</small>
+            {secondaryNav.length && (
+              <ul className="list-inline mb-0">
+                {secondaryNav.map((item, i) => (
+                  <li className="list-inline-item" key={i}>
+                    <Link href={item.path} prefetch={false}>
+                      <a>{item.label}</a>
+                    </Link>
+                    <span className={styles.divider}>|</span>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <p>&copy; copyright {new Date().getFullYear()}</p>
           </div>
         </div>
       </div>

--- a/website/src/components/Footer.js
+++ b/website/src/components/Footer.js
@@ -71,7 +71,7 @@ export default function Footer() {
                 {item.children && item.children.length > 0 && (
                   <ul className="list-unstyled">
                     {item.children.map((item, i) => (
-                      <li key={`primary-${i}`}>
+                      <li key={i}>
                         <Link href={item.path}>
                           <a>{item.label}</a>
                         </Link>

--- a/website/src/components/Footer.module.scss
+++ b/website/src/components/Footer.module.scss
@@ -15,26 +15,33 @@
   }
 }
 
-.nav {
+/* stylelint-disable no-descending-specificity */
+
+.primary {
+  font-size: rem-calc(18px);
+
+  .topLevel {
+    color: $white;
+    font-size: rem-calc(20px);
+    font-weight: bold;
+  }
+
   li {
     margin-right: 0;
-
-    &::after {
-      padding-left: 0.5rem;
-      color: $gray-300;
-      content: '|';
-    }
-
-    &:last-child {
-      &::after {
-        content: '';
-      }
-    }
   }
 }
 
 .copyright {
+  color: $gray-400;
   font-size: rem-calc(14px);
+
+  a {
+    color: $gray-400;
+
+    &:hover {
+      color: $white;
+    }
+  }
 
   .divider {
     padding-left: 10px;
@@ -43,6 +50,16 @@
   li:last-of-type {
     .divider {
       display: none;
+    }
+  }
+}
+
+.social {
+  a {
+    color: $gray-400;
+
+    &:hover {
+      color: $white;
     }
   }
 }

--- a/website/src/components/Footer.module.scss
+++ b/website/src/components/Footer.module.scss
@@ -32,3 +32,17 @@
     }
   }
 }
+
+.copyright {
+  font-size: rem-calc(14px);
+
+  .divider {
+    padding-left: 10px;
+  }
+
+  li:last-of-type {
+    .divider {
+      display: none;
+    }
+  }
+}

--- a/website/src/components/Header.js
+++ b/website/src/components/Header.js
@@ -3,11 +3,22 @@ import GlobalsContext from 'contexts/GlobalsContext';
 import { META } from 'lib/constants';
 import formatMenu from 'lib/formatMenu';
 import Link from 'next/link';
-import { useContext } from 'react';
+import { useContext, useState } from 'react';
+import { RiMenuFill, RiCloseFill } from 'react-icons/ri';
 import styles from './Header.module.scss';
 
 export default function Header() {
   const globals = useContext(GlobalsContext);
+  const [navOpen, setNavOpen] = useState(false);
+
+  function handleHamburgerClick(event) {
+    setNavOpen(!navOpen);
+  }
+
+  function handleClose(event) {
+    setNavOpen(false);
+  }
+
   let headerNav = [];
 
   if (Array.isArray(globals?.menuHeader?.nodes)) {
@@ -16,30 +27,95 @@ export default function Header() {
 
   let hideNav = globals?.pageOptions?.headerHideNav || false;
 
+  function MobileNav() {
+    return (
+      <div
+        className={cx([
+          styles.mobileNav,
+          {
+            // invisible: !navOpen,
+            // [styles.isHidden]: !navOpen,
+            // visible: navOpen,
+            [styles.isVisible]: navOpen,
+          },
+        ])}
+      >
+        <a className={styles.close} onClick={handleClose}>
+          <RiCloseFill />
+        </a>
+        <div className={styles.mobileNavInner}>
+          <div className="container">
+            <div className="row">
+              <div className="col-12 text-center text-white">
+                {headerNav.length > 0 && (
+                  <ul className="list-unstyled">
+                    {headerNav.map((item, i) => (
+                      <li key={i}>
+                        <Link href={item.path} prefetch={false}>
+                          <a
+                            className={cx(['text-nowrap'])}
+                            onClick={handleClose}
+                          >
+                            {item.label}
+                          </a>
+                        </Link>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  function DesktopNav() {
+    return (
+      <ul className={cx([styles.nav, 'list-inline'])}>
+        {headerNav.map((item, i) => (
+          <li className="list-inline-item" key={i}>
+            <a href={item.path}>{item.label}</a>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
   return (
     <header className={styles.header}>
       <div className="container">
-        <div className="row align-items-center">
+        <div className="row align-items-center justify-content-between">
           <div className="col">
             {META.siteName && (
               <div className={styles.logo}>
                 <Link href="/" passHref>
-                  <h1>{META.siteName}</h1>
+                  {META.siteName}
                 </Link>
               </div>
             )}
           </div>
-          <div className="col text-end">
+          <div className="col-3 col-sm-1 col-lg-auto text-end">
             {!hideNav && headerNav.length > 0 && (
-              <ul className={cx([styles.nav, 'list-inline'])}>
-                {headerNav.map((item, i) => (
-                  <li className="list-inline-item" key={i}>
-                    <a href={item.path}>{item.label}</a>
-                  </li>
-                ))}
-              </ul>
+              <>
+                <div
+                  className={cx([
+                    'd-lg-none text-end align-self-center',
+                    styles.hamburger,
+                  ])}
+                >
+                  <a onClick={handleHamburgerClick}>
+                    <RiMenuFill />
+                  </a>
+                </div>
+                <div className={cx(['d-none d-lg-block'])}>
+                  <DesktopNav />
+                </div>
+              </>
             )}
           </div>
+          <MobileNav />
         </div>
       </div>
     </header>

--- a/website/src/components/Header.js
+++ b/website/src/components/Header.js
@@ -1,32 +1,44 @@
+import cx from 'classnames';
 import GlobalsContext from 'contexts/GlobalsContext';
-import _get from 'lodash/get';
+import { META } from 'lib/constants';
+import formatMenu from 'lib/formatMenu';
 import Link from 'next/link';
 import { useContext } from 'react';
 import styles from './Header.module.scss';
 
 export default function Header() {
   const globals = useContext(GlobalsContext);
-  const menus = _get(globals, 'menus.nodes[0].menuItems.nodes', []);
+  let headerNav = [];
+
+  if (Array.isArray(globals?.menuHeader?.nodes)) {
+    headerNav = formatMenu(globals.menuHeader.nodes);
+  }
+
+  let hideNav = globals?.pageOptions?.headerHideNav || false;
 
   return (
     <header className={styles.header}>
       <div className="container">
-        <div className="row ">
+        <div className="row align-items-center">
           <div className="col">
-            <div className={styles.logo}>
-              <Link href="/">
-                <h1>Site Title</h1>
-              </Link>
-            </div>
+            {META.siteName && (
+              <div className={styles.logo}>
+                <Link href="/" passHref>
+                  <h1>{META.siteName}</h1>
+                </Link>
+              </div>
+            )}
           </div>
           <div className="col text-end">
-            <ul className={`${styles.nav} list-inline"`}>
-              {menus.map((item, i) => (
-                <li className="list-inline-item" key={i}>
-                  <a href={item.path}>{item.label}</a>
-                </li>
-              ))}
-            </ul>
+            {!hideNav && headerNav.length > 0 && (
+              <ul className={cx([styles.nav, 'list-inline'])}>
+                {headerNav.map((item, i) => (
+                  <li className="list-inline-item" key={i}>
+                    <a href={item.path}>{item.label}</a>
+                  </li>
+                ))}
+              </ul>
+            )}
           </div>
         </div>
       </div>

--- a/website/src/components/Header.module.scss
+++ b/website/src/components/Header.module.scss
@@ -9,12 +9,19 @@
 
 .logo {
   margin: 0;
-  font-size: 18px;
+  font-size: rem-calc(18px);
   text-transform: uppercase;
 }
 
 .nav {
+  margin: 0;
+  font-size: rem-calc(18px);
+  text-transform: uppercase;
+
   a {
+    margin-right: 5px;
+    margin-left: 5px;
     color: $white;
+    text-decoration: none;
   }
 }

--- a/website/src/components/Header.module.scss
+++ b/website/src/components/Header.module.scss
@@ -1,16 +1,35 @@
 @import 'styles/_scaffold';
 
 .header {
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: 30px;
+  padding-bottom: 30px;
   background: $primary;
   color: $white;
 }
 
 .logo {
+  --minFontSize: 16px;
+  --maxFontSize: 48px;
+  --scaler: 10vw;
+
   margin: 0;
-  font-size: rem-calc(18px);
+  color: $white;
+  font-size: clamp(
+    var(--minFontSize),
+    var(--scaler),
+    var(--maxFontSize)
+  );
   text-transform: uppercase;
+  // font-size: rem-calc(18px);
+
+  a {
+    color: $white;
+    text-decoration: none;
+  }
+
+  // @include media-breakpoint-up(lg) {
+  //   font-size: rem-calc(48px);
+  // }
 }
 
 .nav {
@@ -23,5 +42,69 @@
     margin-left: 5px;
     color: $white;
     text-decoration: none;
+  }
+}
+
+// Mobile Nav
+.mobileNav {
+  position: fixed;
+  z-index: 1000;
+  top: 0;
+  left: 0;
+  width: 0;
+  height: 0;
+  background: rgba($primary, 1);
+  color: $white;
+  opacity: 0;
+  // transition: all 0.5s ease-in-out;
+  // transition: opacity 1.35s ease-in-out;
+  transition: opacity 1s ease-in-out;
+  visibility: hidden;
+
+  &.isVisible {
+    width: 100%;
+    height: 100vh;
+    opacity: 1;
+    visibility: visible;
+  }
+
+  .mobileNavInner {
+    position: relative;
+    padding-top: 60px;
+  }
+
+  .close {
+    position: absolute;
+    z-index: 1001;
+    top: 20px;
+    right: 20px;
+    display: inline-block;
+    color: $white;
+    font-size: rem-calc(26px);
+
+    &:hover {
+      cursor: pointer;
+    }
+  }
+
+  li {
+    margin-bottom: 10px;
+  }
+
+  a {
+    color: $white;
+    text-decoration: none;
+  }
+}
+
+.hamburger {
+  font-size: 26px;
+
+  a {
+    display: inline-block;
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 }

--- a/website/src/components/Header.module.scss
+++ b/website/src/components/Header.module.scss
@@ -8,28 +8,19 @@
 }
 
 .logo {
-  --minFontSize: 16px;
-  --maxFontSize: 48px;
-  --scaler: 10vw;
-
   margin: 0;
   color: $white;
-  font-size: clamp(
-    var(--minFontSize),
-    var(--scaler),
-    var(--maxFontSize)
-  );
+  font-size: rem-calc(18px);
   text-transform: uppercase;
-  // font-size: rem-calc(18px);
+
+  @include media-breakpoint-up(lg) {
+    font-size: rem-calc(36px);
+  }
 
   a {
     color: $white;
     text-decoration: none;
   }
-
-  // @include media-breakpoint-up(lg) {
-  //   font-size: rem-calc(48px);
-  // }
 }
 
 .nav {

--- a/website/src/lib/formatMenu.js
+++ b/website/src/lib/formatMenu.js
@@ -1,0 +1,26 @@
+// https://www.wpgraphql.com/docs/menus/#hierarchical-data
+/* eslint-disable */
+
+export default function formatMenu(
+  data = [],
+  {
+    idKey = 'id',
+    parentKey = 'parentId',
+    childrenKey = 'children',
+  } = {},
+) {
+  const tree = [];
+  const childrenOf = {};
+  data.forEach((item) => {
+    const newItem = { ...item };
+    const { [idKey]: id, [parentKey]: parentId = 0 } = newItem;
+    childrenOf[id] = childrenOf[id] || [];
+    newItem[childrenKey] = childrenOf[id];
+    parentId
+      ? (childrenOf[parentId] = childrenOf[parentId] || []).push(
+          newItem,
+        )
+      : tree.push(newItem);
+  });
+  return tree;
+}

--- a/website/src/lib/wordpress.js
+++ b/website/src/lib/wordpress.js
@@ -10,6 +10,8 @@ async function fetchAPI(query, { variables } = {}) {
     ] = `Bearer ${process.env.WORDPRESS_AUTH_REFRESH_TOKEN}`;
   }
 
+  console.log('API', WORDPRESS_API_URL);
+  console.log('variables', variables);
   const res = await fetch(WORDPRESS_API_URL, {
     method: 'POST',
     headers,

--- a/website/src/lib/wordpress.js
+++ b/website/src/lib/wordpress.js
@@ -21,7 +21,7 @@ async function fetchAPI(query, { variables } = {}) {
 
   const json = await res.json();
   if (json.errors) {
-    console.error(json.errors);
+    console.error(JSON.stringify(json.errors, null, 2));
     throw new Error('Failed to fetch API');
   }
   // console.log("graphql results", JSON.stringify(json.data, null, 2));

--- a/website/src/lib/wordpress.js
+++ b/website/src/lib/wordpress.js
@@ -67,7 +67,9 @@ let fragmentSEO = /* GraphQL */ `
 let fragmentPageOptions = /* GraphQL */ `
   acfPageOptions {
     footerHideNav
+    footerHideSearch
     footerHideSignup
+    footerHideSocial
     footerStyle
     headerHideNav
   }
@@ -219,11 +221,13 @@ export async function getContent(slug, preview, previewData) {
           content
           ${generateFlex('Page')}
           ${fragmentSEO}
+          ${fragmentPageOptions}
         }
         ... on Post {
           content
           ${generateFlex('Post')}
           ${fragmentSEO}
+          ${fragmentPageOptions}
         }
       }
     }
@@ -370,36 +374,48 @@ export async function getCategories() {
  * (Might merge into other queries via fragment)
  * */
 export async function getGlobalProps() {
+  let fragmentMenu = /* GraphQL */ `
+    nodes {
+      id
+      databaseId
+      label
+      parentId
+      url
+      path
+    }
+`;
+
   let query = /* GraphQL */ `
     fragment Menus on RootQuery {
-      menus {
-        nodes {
-          id
-          databaseId
-          name
-          menuItems {
-            nodes {
-              id
-              label
-              parentId
-              url
-              path
-            }
-          }
-        }
+      menuHeader: menuItems(where: { location: HEADER }, first: 100) {
+        ${fragmentMenu}
+      }
+      menuFooter: menuItems(where: { location: FOOTER }, first: 100) {
+        ${fragmentMenu}
+      }
+      menuFooterSocial: menuItems(where: { location: FOOTER_SOCIAL }, first: 100) {
+        ${fragmentMenu}
+      }
+      menuFooterSecondary: menuItems(where: { location: FOOTER_SECONDARY }, first: 100) {
+        ${fragmentMenu}
       }
     }
 
+    # fragment GlobalOptions on RootQuery {
+    #   themeSettings {
+    #     acfGlobalOptions {
+    #       fieldGroupName
+    #       newsletterButton
+    #       newsletterHeading
+    #     }
+    #   }
+    # }
+
     query AllGlobals {
       ...Menus
+      # ...GlobalOptions
     }
   `;
-
-  /*
-    fragment GlobalOptions on RootQuery {
-      themeSettings
-    }
-  */
 
   const data = await fetchAPI(query);
   return data;

--- a/website/src/lib/wordpress.js
+++ b/website/src/lib/wordpress.js
@@ -10,8 +10,8 @@ async function fetchAPI(query, { variables } = {}) {
     ] = `Bearer ${process.env.WORDPRESS_AUTH_REFRESH_TOKEN}`;
   }
 
-  console.log('API', WORDPRESS_API_URL);
-  console.log('variables', variables);
+  // console.log('API', WORDPRESS_API_URL);
+  // console.log('variables', variables);
   const res = await fetch(WORDPRESS_API_URL, {
     method: 'POST',
     headers,

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -84,7 +84,10 @@ export async function getStaticProps({
   if (!params.slug?.length) {
     return {
       props: {
-        globals,
+        globals: {
+          ...globals,
+          pageOptions: null,
+        },
         isHome: true,
       },
     };
@@ -106,7 +109,7 @@ export async function getStaticProps({
 
   return {
     props: {
-      globals,
+      globals: { ...globals, pageOptions: data.post?.acfPageOptions },
       preview,
       post: data.post,
       flexSections: data.post?.acfFlex?.flexContent || null,

--- a/website/src/styles/_custom.scss
+++ b/website/src/styles/_custom.scss
@@ -81,7 +81,7 @@ $theme-colors: map-merge($theme-colors, $custom-colors);
 //
 
 $font-family-sans-serif: $font-sans;
-$font-family-base: $font-serif;
+$font-family-base: $font-sans;
 $headings-font-family: $font-heading;
 $font-size-base: 1rem;
 $line-height-base: 1.5;

--- a/website/src/styles/shared/_type.scss
+++ b/website/src/styles/shared/_type.scss
@@ -34,6 +34,14 @@ p {
   }
 }
 
+.text-white {
+  &,
+  a,
+  a:hover {
+    color: white;
+  }
+}
+
 // focus
 
 :focus {

--- a/wordpress/wp-content/themes/headless/acf-json/group_6023926033c13.json
+++ b/wordpress/wp-content/themes/headless/acf-json/group_6023926033c13.json
@@ -1,0 +1,192 @@
+{
+    "key": "group_6023926033c13",
+    "title": "Shared: Page Options",
+    "fields": [
+        {
+            "key": "field_602393825d0af",
+            "label": "Header Hide Nav",
+            "name": "header_hide_nav",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "message": "",
+            "default_value": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_6088b428e4936",
+            "label": "Footer Style",
+            "name": "footer_style",
+            "type": "select",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "choices": {
+                "default": "Default",
+                "basic": "Basic",
+                "custom": "Custom"
+            },
+            "default_value": "default",
+            "allow_null": 0,
+            "multiple": 0,
+            "ui": 0,
+            "return_format": "value",
+            "ajax": 0,
+            "placeholder": ""
+        },
+        {
+            "key": "field_602393cc5d0b0",
+            "label": "Footer Hide Signup",
+            "name": "footer_hide_signup",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_6088b428e4936",
+                        "operator": "==",
+                        "value": "custom"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "message": "",
+            "default_value": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_602394065d0b2",
+            "label": "Footer Hide Nav",
+            "name": "footer_hide_nav",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_6088b428e4936",
+                        "operator": "==",
+                        "value": "custom"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "message": "",
+            "default_value": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_60d4b920fcf45",
+            "label": "Footer Hide Social",
+            "name": "footer_hide_social",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_6088b428e4936",
+                        "operator": "==",
+                        "value": "custom"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "message": "",
+            "default_value": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        },
+        {
+            "key": "field_60b504866a11b",
+            "label": "Footer Hide Search",
+            "name": "footer_hide_search",
+            "type": "true_false",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": [
+                [
+                    {
+                        "field": "field_6088b428e4936",
+                        "operator": "==",
+                        "value": "custom"
+                    }
+                ]
+            ],
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "show_in_graphql": 1,
+            "message": "",
+            "default_value": 0,
+            "ui": 0,
+            "ui_on_text": "",
+            "ui_off_text": ""
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "page"
+            }
+        ],
+        [
+            {
+                "param": "post_type",
+                "operator": "==",
+                "value": "post"
+            }
+        ]
+    ],
+    "menu_order": 100,
+    "position": "side",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_graphql": 1,
+    "graphql_field_name": "acfPageOptions",
+    "modified": 1624553789
+}

--- a/wordpress/wp-content/themes/headless/setup/helpers/menus.php
+++ b/wordpress/wp-content/themes/headless/setup/helpers/menus.php
@@ -1,20 +1,18 @@
 <?php
 
 //
-// Add Menus to Timber
+// Add Menus to Wordpress
 //
 
-register_nav_menus(array(
+function bubs_register_nav_menu(){
+  register_nav_menus(array(
     'header' => 'Header Navigation',
-    // 'footer' => 'Footer Navigation'
-));
-
-function timber_menus( $data ) {
-    $data["header_menu"] = new TimberMenu('header-menu');
-    $data["footer_menu"] = new TimberMenu('footer-menu');
-    return $data;
+    'footer' => 'Footer Navigation',
+    'footer_secondary' => 'Footer Secondary Navigation',
+    'footer_social' => 'Social',
+  ));
 }
 
-add_filter( 'timber_context', 'timber_menus' );
+add_action( 'after_setup_theme', 'bubs_register_nav_menu', 0 );
 
 ?>


### PR DESCRIPTION
Adjustments to how we load in header/footer elements based on some recent sites:

* [x] Clean up menu loading logic from graphql/wp, using named locations so things don't break when users change menus, and we don't have to filter one mega-list of all menu items.
* [x] `formatMenu` utility for converting flat graphql menus into nested arrays.
* [x] Header/footer default styles
* [x] Mobile hamburger + slide down menu
* [x] Global options for hiding certain elements via page options