### PR TITLE
substitude divide() or math.divide or multiply by decimal (when it's …

### DIFF
--- a/website/.stylelintrc.json
+++ b/website/.stylelintrc.json
@@ -10,6 +10,7 @@
   "rules": {
     "at-rule-no-unknown": null,
     "scss/at-rule-no-unknown": true,
+    "selector-pseudo-class-no-unknown": null,
     "max-nesting-depth": 3,
     "at-rule-empty-line-before": [
       "always",

--- a/website/src/components/post/PostBody.module.scss
+++ b/website/src/components/post/PostBody.module.scss
@@ -12,23 +12,23 @@
 
   :global .aligncenter {
     display: block;
-    margin: ($font-size-base / 2) auto;
+    margin: divide($font-size-base, 2) auto;
   }
 
   :global .alignleft,
   :global .alignright {
-    margin-bottom: ($font-size-base / 2);
+    margin-bottom: divide($font-size-base, 2);
   }
 
   @include media-breakpoint-up(sm) {
     // Only float if not on an extra small device
     :global .alignleft {
-      margin-right: ($font-size-base / 2);
+      margin-right: divide($font-size-base, 2);
       float: left;
     }
 
     :global .alignright {
-      margin-left: ($font-size-base / 2);
+      margin-left: divide($font-size-base, 2);
       float: right;
     }
   }

--- a/website/src/styles/shared/_utils.scss
+++ b/website/src/styles/shared/_utils.scss
@@ -1,13 +1,15 @@
+@use "sass:math"; // for / div replacement
+
 // foundation's function
 // https://gist.github.com/kylewebdev/f36acbfd2e9257d88253
 $rem-base: 16px;
 
 @function strip-unit($num) {
-  @return $num / ($num * 0 + 1);
+  @return math.div($num, ($num * 0 + 1));
 }
 
 @function convert-to-rem($value, $base-value: $rem-base) {
-  $value: strip-unit($value) / strip-unit($base-value) * 1rem;
+  $value: math.div(strip-unit($value), strip-unit($base-value)) * 1rem;
 
   @if ($value == 0) {
     $value: 0;


### PR DESCRIPTION
…a number) to comply with the sasslang request not to use '/' as divisor anymore

This PR wraps the #117 request to not use '/' as a divisor in sass anymore. 

The strategy is similar as [Bootstrap's fix](https://github.com/twbs/bootstrap/search?q=sass%3Amath&type=commits) in `5.0.2` . In preference order this is what we did:: 

* If it's a division by a number, just change to multiply by decimal ($x / 2 -> $x * 0.5).
* Whenever you can, use Bootstrap's [new divide() utility function](https://github.com/twbs/bootstrap/blob/be17444756c48e3a892c36507f859cd841bd8c1f/scss/_functions.scss#L223) . More portable. 
* If neither of those applies, use [Sass's recommended math.div function](https://sass-lang.com/documentation/breaking-changes/slash-div#transition-period). We needed to do this in  one file: `shared/_utils.scss` .


Tested on my local machine. No more divisor deprecation warnings after making the changes here. 