### PR TITLE
108 static path redirects

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -31,4 +31,17 @@ module.exports = withBundleAnalyzer({
       },
     ];
   },
+
+  // For some projects, /wp-content upload paths still need to resolve
+  // Proxy the resource up to Wordpress. Uncomment to enable.
+  /*async redirects() {
+    return [
+      {
+        source: '/wp-content/uploads/:path*',
+        destination:
+          'https://bubsnext.wpengine.com/wp-content/uploads/:path*',
+        permanent: true,
+      },
+    ];
+  },*/
 });

--- a/website/src/lib/utils.js
+++ b/website/src/lib/utils.js
@@ -5,3 +5,32 @@ export function trimTrailingSlash(str) {
 
   return str.replace(/\/$/, '');
 }
+
+export function isStaticFile(fileName) {
+  if (!fileName.includes('.')) {
+    return false;
+  }
+
+  const staticExtensions = [
+    // Text Files
+    'txt',
+    'css',
+    'js',
+
+    // Img Files
+    'gif',
+    'png',
+    'jpg',
+    'ico',
+    'svg',
+
+    // Other downloadable files
+    'pdf',
+    'mov',
+    'mp4',
+  ];
+
+  const segments = fileName.split('.');
+  const ext = segments[segments.length - 1];
+  return staticExtensions.includes(ext);
+}

--- a/website/src/lib/utils.js
+++ b/website/src/lib/utils.js
@@ -6,6 +6,11 @@ export function trimTrailingSlash(str) {
   return str.replace(/\/$/, '');
 }
 
+/**
+ * Lightweight determination if filename is a static asset. Avoids external deps.
+ * @param {string} fileName Name of the path or file being requested
+ * @returns {bool}
+ */
 export function isStaticFile(fileName) {
   if (!fileName.includes('.')) {
     return false;

--- a/website/src/lib/wordpress.js
+++ b/website/src/lib/wordpress.js
@@ -494,6 +494,17 @@ export async function getGlobalProps() {
       }
     }
 
+    fragment Redirects on RootQuery {
+      redirection {
+        redirects {
+          matchType
+          code
+          target
+          origin
+        }
+      }
+    }
+
     # fragment GlobalOptions on RootQuery {
     #   themeSettings {
     #     acfGlobalOptions {
@@ -507,6 +518,7 @@ export async function getGlobalProps() {
     query AllGlobals {
       ...Menus
       ...SEO
+      ...Redirects
       # ...GlobalOptions
     }
   `;

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -82,6 +82,20 @@ export async function getStaticProps({
   preview = false,
   previewData,
 }) {
+  let slug = '/';
+
+  if (params.slug?.length) {
+    slug += params.slug.join('/');
+  }
+
+  // To reduce unnecessary load on Wordpress, don't query GraphQL for common static files.
+  // This prevents things like favicons, device icons.
+  if (slug && isStaticFile(slug)) {
+    return {
+      notFound: true,
+    };
+  }
+
   const globals = await getGlobalProps();
 
   if (Array.isArray(params.slug)) {
@@ -111,20 +125,6 @@ export async function getStaticProps({
         },
         isHome: true,
       },
-    };
-  }
-
-  let slug = '/';
-
-  if (params.slug?.length) {
-    slug += params.slug.join('/');
-  }
-
-  // To reduce unnecessary load on Wordpress, don't query GraphQL for common static files.
-  // This prevents things like favicons, device icons.
-  if (slug && isStaticFile(slug)) {
-    return {
-      notFound: true,
     };
   }
 

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -7,6 +7,7 @@ import {
   getGlobalProps,
   getAllContentWithSlug,
 } from 'lib/wordpress';
+import _find from 'lodash/find';
 
 import { GlobalsProvider } from '../contexts/GlobalsContext';
 
@@ -82,6 +83,19 @@ export async function getStaticProps({
   previewData,
 }) {
   const globals = await getGlobalProps();
+
+  const redirect = _find(globals?.redirection?.redirects, {
+    origin: `/${params.slug[0]}/`,
+  });
+
+  if (redirect) {
+    return {
+      redirect: {
+        destination: redirect.target,
+        statusCode: redirect.code,
+      },
+    };
+  }
 
   // if your homepage doesn't come from WP, you need this to custom render and not get a 404
   // next doesn't let you have index.js and [[...slug.js]]

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -1,6 +1,7 @@
 import Flex from 'components/flex/Flex';
 import LayoutDefault from 'components/layouts/LayoutDefault';
 import PostBody from 'components/post/PostBody';
+import { isStaticFile } from 'lib/utils';
 import {
   getContent,
   getGlobalProps,
@@ -101,6 +102,14 @@ export async function getStaticProps({
 
   if (params.slug?.length) {
     slug += params.slug.join('/');
+  }
+
+  // To reduce unnecessary load on Wordpress, don't query GraphQL for common static files.
+  // This prevents things like favicons, device icons.
+  if (slug && isStaticFile(slug)) {
+    return {
+      notFound: true,
+    };
   }
 
   const data = await getContent(slug, preview, previewData);

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -84,17 +84,19 @@ export async function getStaticProps({
 }) {
   const globals = await getGlobalProps();
 
-  const redirect = _find(globals?.redirection?.redirects, {
-    origin: `/${params.slug[0]}/`,
-  });
+  if (Array.isArray(params.slug)) {
+    const redirect = _find(globals?.redirection?.redirects, {
+      origin: `/${params.slug[0]}/`,
+    });
 
-  if (redirect) {
-    return {
-      redirect: {
-        destination: redirect.target,
-        statusCode: redirect.code,
-      },
-    };
+    if (redirect) {
+      return {
+        redirect: {
+          destination: redirect.target,
+          statusCode: redirect.code,
+        },
+      };
+    }
   }
 
   // if your homepage doesn't come from WP, you need this to custom render and not get a 404

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -7,7 +7,6 @@ import {
   getGlobalProps,
   getAllContentWithSlug,
 } from 'lib/wordpress';
-import _find from 'lodash/find';
 
 import { GlobalsProvider } from '../contexts/GlobalsContext';
 
@@ -99,9 +98,9 @@ export async function getStaticProps({
   const globals = await getGlobalProps();
 
   if (Array.isArray(params.slug)) {
-    const redirect = _find(globals?.redirection?.redirects, {
-      origin: `/${params.slug[0]}/`,
-    });
+    const redirect = globals?.redirection?.redirects.find(
+      (row) => row.origin === `/${params.slug[0]}/`,
+    );
 
     if (redirect) {
       return {

--- a/website/src/pages/posts/[[...slug]].js
+++ b/website/src/pages/posts/[[...slug]].js
@@ -4,7 +4,6 @@ import PostArchive from 'components/post/PostArchive';
 import { GlobalsProvider } from 'contexts/GlobalsContext';
 import { staticPropHelper, staticPathGenerator } from 'lib/archive';
 import { getContent, getGlobalProps } from 'lib/wordpress';
-import _find from 'lodash/find';
 import { useRouter } from 'next/router';
 
 function PostsSinglePage({ post, globals, preview }) {
@@ -64,9 +63,9 @@ export async function getStaticProps(context) {
   const globals = await getGlobalProps();
 
   if (Array.isArray(context.params.slug)) {
-    const redirect = _find(globals?.redirection?.redirects, {
-      origin: `/posts/${context.params.slug[0]}/`,
-    });
+    const redirect = globals?.redirection?.redirects.find(
+      (row) => row.origin === `/posts/${context.params.slug[0]}/`,
+    );
 
     if (redirect) {
       return {
@@ -104,8 +103,6 @@ export async function getStaticProps(context) {
       context.preview,
       context.previewData,
     );
-
-    console.log('contentNode', context.params.slug[0], contentNode);
 
     return {
       props: {

--- a/website/src/pages/posts/[[...slug]].js
+++ b/website/src/pages/posts/[[...slug]].js
@@ -4,6 +4,7 @@ import PostArchive from 'components/post/PostArchive';
 import { GlobalsProvider } from 'contexts/GlobalsContext';
 import { staticPropHelper, staticPathGenerator } from 'lib/archive';
 import { getContent, getGlobalProps } from 'lib/wordpress';
+import _find from 'lodash/find';
 import { useRouter } from 'next/router';
 
 function PostsSinglePage({ post, globals, preview }) {
@@ -61,6 +62,20 @@ export async function getStaticProps(context) {
   // Generate props for Post Index page
   //
   const globals = await getGlobalProps();
+
+  const redirect = _find(globals?.redirection?.redirects, {
+    origin: `/posts/${context.params.slug[0]}/`,
+  });
+
+  if (redirect) {
+    return {
+      redirect: {
+        destination: redirect.target,
+        statusCode: redirect.code,
+      },
+    };
+  }
+
   const indexProps = await staticPropHelper(
     context,
     'POST',

--- a/website/src/pages/posts/[[...slug]].js
+++ b/website/src/pages/posts/[[...slug]].js
@@ -63,17 +63,19 @@ export async function getStaticProps(context) {
   //
   const globals = await getGlobalProps();
 
-  const redirect = _find(globals?.redirection?.redirects, {
-    origin: `/posts/${context.params.slug[0]}/`,
-  });
+  if (Array.isArray(context.params.slug)) {
+    const redirect = _find(globals?.redirection?.redirects, {
+      origin: `/posts/${context.params.slug[0]}/`,
+    });
 
-  if (redirect) {
-    return {
-      redirect: {
-        destination: redirect.target,
-        statusCode: redirect.code,
-      },
-    };
+    if (redirect) {
+      return {
+        redirect: {
+          destination: redirect.target,
+          statusCode: redirect.code,
+        },
+      };
+    }
   }
 
   const indexProps = await staticPropHelper(

--- a/wordpress/composer.json
+++ b/wordpress/composer.json
@@ -63,10 +63,12 @@
     "wpackagist-plugin/term-management-tools": "2.0.1",
     "wpackagist-plugin/wordpress-seo": "17.0",
     "wpackagist-plugin/wp-graphql": "1.6.4",
+    "wpackagist-plugin/redirection": "5.1.3",
     "wp-graphql/wp-graphql-acf": "0.5.3",
     "wp-graphql/wp-graphql-tax-query": "0.1.0",
     "ashhitch/wp-graphql-yoast-seo": "4.15.0",
-    "wpackagist-plugin/safe-svg": "^1.9"
+    "wpackagist-plugin/safe-svg": "^1.9",
+    "ashhitch/wp-graphql-redirection": "^0.0.3"
   },
   "config": {
     "optimize-autoloader": true,


### PR DESCRIPTION
closes #108 

## Testing
* curl -I https://bubs-next-git-108-static-path-redirects-patronage.vercel.app/test.png
* curl -I https://bubs-next-git-108-static-path-redirects-patronage.vercel.app/test-redirect/

## Changes
* Redirection Plugin
* Pass redirects into Globals, where getStaticProps checks the pathname against the list, and redirects to the designated URL
* Check slug for known file extensions, sending a 404 if matches, to prevent spurious graphql requests to wordpress