### PR TITLE
handle various url types in redirects

### DIFF
--- a/website/src/lib/utils.js
+++ b/website/src/lib/utils.js
@@ -6,6 +6,14 @@ export function trimTrailingSlash(str) {
   return str.replace(/\/$/, '');
 }
 
+export function trimLeadingSlash(str) {
+  if (!str) {
+    return str;
+  }
+
+  return str.replace(/^\/+/, '');
+}
+
 /**
  * Lightweight determination if filename is a static asset. Avoids external deps.
  * @param {string} fileName Name of the path or file being requested

--- a/website/src/lib/utils.js
+++ b/website/src/lib/utils.js
@@ -1,5 +1,5 @@
 export function trimTrailingSlash(str) {
-  if (!str) {
+  if (!str || str === '/' ) {
     return str;
   }
 


### PR DESCRIPTION
To test.

Setup redirects for:
* /internal => /
* /internal/anchor => /#pledge
* /external => https://www.patronage.org

Using Curl, all of the following should work (once setup in WP):

curl -I https://bubs.patronage.org/internal
curl -I https://bubs.patronage.org/internal/
curl -I https://bubs.patronage.org/internal/anchor
curl -I https://bubs.patronage.org/internal/anchor/
curl -I https://bubs.patronage.org/external
curl -I https://bubs.patronage.org/external/

refs #153 