### PR TITLE
Security Headers 

### DIFF
--- a/website/next.config.js
+++ b/website/next.config.js
@@ -2,6 +2,23 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
   enabled: process.env.ANALYZE === 'true',
 });
 
+const securityHeaders = [{
+  key: 'Strict-Transport-Security',
+  value: 'max-age=63072000; includeSubDomains; preload'
+}, {
+  key: 'X-Content-Type-Options',
+  value: 'nosniff'
+}, {
+  key: 'X-Frame-Options',
+  value: 'SAMEORIGIN'
+}, {
+  key: 'Content-Security-Policy',
+  value: 'upgrade-insecure-requests'
+}, {
+  key: 'X-XSS-Protection',
+  value: '1; mode=block'
+}];
+
 module.exports = withBundleAnalyzer({
   // Match Wordpress
   trailingSlash: true,
@@ -28,6 +45,16 @@ module.exports = withBundleAnalyzer({
       {
         source: '/feed',
         destination: '/api/upstream-proxy',
+      },
+    ];
+  },
+
+  async headers() {
+    return [
+      {
+        // Apply these headers to all routes in your application.
+        source: '/(.*)',
+        headers: securityHeaders,
       },
     ];
   },

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -9,14 +9,11 @@ const securityHeaders = [{
   key: 'X-Content-Type-Options',
   value: 'nosniff'
 }, {
-  key: 'X-Frame-Options',
-  value: 'SAMEORIGIN'
-}, {
   key: 'Content-Security-Policy',
   value: 'upgrade-insecure-requests'
 }, {
   key: 'X-XSS-Protection',
-  value: '1; mode=block'
+  value: '1'
 }];
 
 module.exports = withBundleAnalyzer({


### PR DESCRIPTION
Small set of security headers to improve security score on webpagetest

https://nextjs.org/docs/advanced-features/security-headers

Here's the ones that webpagetest wants:
* HSTS: this tells browsers that the domain and subdomains _must_ be https for the next 2 years. Browsers and OSs are increasingly enforcing this on their own so I don't anticipate any issues
* Content Type Options: this security rule is more for sites with user uploads/downloads
* Frame Options: prevents sites from being loaded within iframes (@chrisherold do you anticipate this interfering with any of our form embeds?)
* Content Security Policy: this is the header that webpagetest wanted the most and the one i was most worried about having to deal with - it seems very difficult to generalize any sort of real policy across sites. Trying to implement actual policies could also cause some difficult to debug errors in development too. After some searching, i found the mildest policy i could just to have something to set - `upgrade-insecure-requests` - like I mentioned above, this is something that browsers are starting to do on their own, so it seems harmless
* XSS Protection - seems to be for older browsers
