### PR TITLE
feat: :lipstick: Children links render as dropdown menus in header.

### DIFF
--- a/website/src/components/Footer.js
+++ b/website/src/components/Footer.js
@@ -65,15 +65,17 @@ export default function Footer() {
           >
             {footerNav.map((item, i) => (
               <div key={i}>
-                <Link href={item.path}>
-                  <a className={styles.topLevel}>{item.label}</a>
+                <Link href={item.path} prefetch={false}>
+                  <a className={styles.topLevel} target={item.target}>
+                    {item.label}
+                  </a>
                 </Link>
                 {item.children && item.children.length > 0 && (
                   <ul className="list-unstyled">
                     {item.children.map((item, i) => (
                       <li key={i}>
-                        <Link href={item.path}>
-                          <a>{item.label}</a>
+                        <Link href={item.path} prefetch={false}>
+                          <a target={item.target}>{item.label}</a>
                         </Link>
                       </li>
                     ))}
@@ -91,7 +93,7 @@ export default function Footer() {
                 {secondaryNav.map((item, i) => (
                   <li className="list-inline-item" key={i}>
                     <Link href={item.path} prefetch={false}>
-                      <a>{item.label}</a>
+                      <a target={item.target}>{item.label}</a>
                     </Link>
                     <span className={styles.divider}>|</span>
                   </li>

--- a/website/src/components/Header.js
+++ b/website/src/components/Header.js
@@ -4,6 +4,7 @@ import { META } from 'lib/constants';
 import formatMenu from 'lib/formatMenu';
 import Link from 'next/link';
 import { useContext, useState } from 'react';
+import { FaChevronDown } from 'react-icons/fa';
 import { RiMenuFill, RiCloseFill } from 'react-icons/ri';
 import styles from './Header.module.scss';
 
@@ -31,6 +32,7 @@ export default function Header() {
     return (
       <div
         className={cx([
+          'text-nowrap',
           styles.mobileNav,
           {
             // invisible: !navOpen,
@@ -50,15 +52,63 @@ export default function Header() {
                 {headerNav.length > 0 && (
                   <ul className="list-unstyled">
                     {headerNav.map((item, i) => (
-                      <li key={i}>
+                      <li
+                        className={cx([
+                          'list-inline-item',
+                          {
+                            [styles.hasDropdown]:
+                              item.children.length > 0,
+                          },
+                        ])}
+                        key={i}
+                      >
                         <Link href={item.path} prefetch={false}>
                           <a
-                            className={cx(['text-nowrap'])}
+                            className={cx([
+                              'text-nowrap',
+                              styles.parent,
+                              item.cssClasses,
+                              item.cssClasses?.map((className) => {
+                                return styles[className];
+                              }),
+                            ])}
                             onClick={handleClose}
                           >
                             {item.label}
                           </a>
                         </Link>
+                        {item.children && item.children.length > 0 && (
+                          <ul
+                            className={cx([
+                              styles.dropdown,
+                              'list-unstyled',
+                            ])}
+                          >
+                            {item.children.map((item, i) => (
+                              <li key={i}>
+                                <Link
+                                  href={item.path}
+                                  prefetch={false}
+                                >
+                                  <a
+                                    className={cx([
+                                      styles.child,
+                                      item.cssClasses,
+                                      item.cssClasses?.map(
+                                        (className) => {
+                                          return styles[className];
+                                        },
+                                      ),
+                                    ])}
+                                    onClick={handleClose}
+                                  >
+                                    {item.label}
+                                  </a>
+                                </Link>
+                              </li>
+                            ))}
+                          </ul>
+                        )}
                       </li>
                     ))}
                   </ul>
@@ -73,10 +123,44 @@ export default function Header() {
 
   function DesktopNav() {
     return (
-      <ul className={cx([styles.nav, 'list-inline'])}>
+      <ul className={cx([styles.desktopNav, 'list-inline'])}>
         {headerNav.map((item, i) => (
-          <li className="list-inline-item" key={i}>
-            <a href={item.path}>{item.label}</a>
+          <li
+            className={cx([
+              'list-inline-item',
+              { [styles.hasDropdown]: item.children.length > 0 },
+            ])}
+            key={i}
+          >
+            <Link href={item.path}>
+              <a
+                className={cx(
+                  styles.parent,
+                  item.cssClasses,
+                  item.cssClasses?.map((className) => {
+                    return styles[className];
+                  }),
+                )}
+              >
+                {item.label}
+                {item.children.length > 0 && (
+                  <span className={styles.arrow}>
+                    <FaChevronDown />
+                  </span>
+                )}
+              </a>
+            </Link>
+            {item.children && item.children.length > 0 && (
+              <ul className={cx([styles.dropdown, 'list-unstyled'])}>
+                {item.children.map((item, i) => (
+                  <li className="list-inline-item" key={i}>
+                    <Link href={item.path}>
+                      <a className={styles.child}>{item.label}</a>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
           </li>
         ))}
       </ul>
@@ -90,8 +174,15 @@ export default function Header() {
           <div className="col">
             {META.siteName && (
               <div className={styles.logo}>
-                <Link href="/" passHref>
-                  {META.siteName}
+                <Link href="/">
+                  <a>{META.siteName}</a>
+                  {/* <Image
+                    src="/img/logo.svg"
+                    width="200"
+                    height="80"
+                    alt={META.title}
+                    className={styles.logo}
+                  /> */}
                 </Link>
               </div>
             )}

--- a/website/src/components/Header.js
+++ b/website/src/components/Header.js
@@ -73,6 +73,7 @@ export default function Header() {
                               }),
                             ])}
                             onClick={handleClose}
+                            target={item.target}
                           >
                             {item.label}
                           </a>
@@ -100,6 +101,7 @@ export default function Header() {
                                         },
                                       ),
                                     ])}
+                                    target={item.target}
                                     onClick={handleClose}
                                   >
                                     {item.label}
@@ -141,6 +143,7 @@ export default function Header() {
                     return styles[className];
                   }),
                 )}
+                target={item.target}
               >
                 {item.label}
                 {item.children.length > 0 && (
@@ -155,7 +158,12 @@ export default function Header() {
                 {item.children.map((item, i) => (
                   <li className="list-inline-item" key={i}>
                     <Link href={item.path}>
-                      <a className={styles.child}>{item.label}</a>
+                      <a
+                        className={styles.child}
+                        target={item.target}
+                      >
+                        {item.label}
+                      </a>
                     </Link>
                   </li>
                 ))}

--- a/website/src/components/Header.module.scss
+++ b/website/src/components/Header.module.scss
@@ -1,4 +1,5 @@
 @import 'styles/_scaffold';
+/* stylelint-disable no-descending-specificity */
 
 .header {
   padding-top: 30px;
@@ -23,20 +24,10 @@
   }
 }
 
-.nav {
-  margin: 0;
-  font-size: rem-calc(18px);
-  text-transform: uppercase;
-
-  a {
-    margin-right: 5px;
-    margin-left: 5px;
-    color: $white;
-    text-decoration: none;
-  }
-}
-
+//
 // Mobile Nav
+//
+
 .mobileNav {
   position: fixed;
   z-index: 1000;
@@ -86,6 +77,21 @@
     color: $white;
     text-decoration: none;
   }
+
+  // subnav
+  .dropdown {
+    margin-top: 16px;
+    margin-bottom: 30px;
+
+    li {
+      margin-bottom: 20px;
+      line-height: 1em;
+    }
+
+    .child {
+      font-size: rem-calc(22px);
+    }
+  }
 }
 
 .hamburger {
@@ -96,6 +102,58 @@
 
     &:hover {
       cursor: pointer;
+    }
+  }
+}
+
+//
+// Desktop Nav
+//
+
+.desktopNav {
+  margin: 0;
+  font-size: rem-calc(18px);
+  text-transform: uppercase;
+
+  a {
+    margin-right: 5px;
+    margin-left: 5px;
+    color: $white;
+    text-decoration: none;
+  }
+
+  .hasDropdown {
+    position: relative;
+
+    .arrow {
+      padding-left: 5px;
+    }
+
+    &:hover {
+      a.parent {
+        color: $white;
+      }
+
+      .dropdown {
+        display: block;
+      }
+    }
+  }
+
+  .dropdown {
+    position: absolute;
+    z-index: 1000;
+    top: 100%;
+    display: none;
+    min-width: 200px;
+    padding: 5px 0;
+    background: rgba($white, 0.9);
+    text-align: left;
+
+    .child {
+      display: block;
+      padding: 5px 0;
+      color: $primary;
     }
   }
 }

--- a/website/src/lib/wordpress.js
+++ b/website/src/lib/wordpress.js
@@ -461,6 +461,8 @@ export async function getGlobalProps() {
       parentId
       url
       path
+      target
+      cssClasses
     }
 `;
 


### PR DESCRIPTION
Also support for WP css classes, and external targeting refs #164 