### PR TITLE
fix: revalidate so pages can be published/unpublished

### DIFF
--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -96,6 +96,8 @@ export async function getStaticProps({
   if (!preview && !data?.contentNode?.slug) {
     return {
       notFound: true,
+      revalidate: 60,
+      props: {},
     };
   }
 

--- a/website/src/pages/posts/[[...slug]].js
+++ b/website/src/pages/posts/[[...slug]].js
@@ -132,6 +132,8 @@ export async function getStaticProps(context) {
   //
   return {
     notFound: true,
+    revalidate: 60,
+    props: {},
   };
 }
 


### PR DESCRIPTION
closes #201

Testing Steps (broken on main, working here):

1) Create a page in WordPress
2) Using `curl -I` visit the page and you should see x-vercel-cache: HIT and an age after running a couple times
3) Unpublish the page, then revisit after the cache gets stale. 

Expected behavior is for the page to return a 404 after the page becomes stale (~60 seconds). Current behavior on main is that the page stays a 200.

Similarly, try caching a page with a 404 status, then publish a page at that path. It should flip from 404 => 200 after the 60 second cache expires.
