### PR TITLE
add env var support for docker db name

### DIFF
--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -1,34 +1,49 @@
-Notes on WP conventions and local dev.
+One of the nice aspects of headless dev compared to traditional wordpress dev is that having a running WP locally becomes optional. Your local Next.js server can easily consume production or staging graphql endpoints with a simple ENV variable adjustment.
+
+Sometimes you will want a local WP instance, for example when adding new ACF fields, WordPress post types, or testing out plugins.
+
+We rely on Docker for this, and below are some details on getting up and running locally.
 
 - Getting running locally
 - Working with databases
 - Working with ACF
 - Working with images
 
-## Theme
+## Docker
 
-The `headless` theme is configured to make some light adjustments to WordPress to support headless dev.
+Inside of the WordPress folder is a docker-commpose.yml file that will spin up a basic WordPress image with a MariaDB database (this is better for Apple Silicon Macbooks).
 
-In `themes/headless/functions.php` there is a `$headless_domain` variable that should be defined for each site. This variable is used to redirect the user whenever they try and access a page URL from WordPress admin.
+The VS Code task `WordPress Docker Recreate` can be run from the task runner as an alias to get your container started.
 
-## WordPress DB
+Inside of the WordPress folder you'll find a .env.sample. You'll want to copy that to .env, and setup a unique database name for the project.
 
-We have a DB import script that will run and import the latest version of a database file that exists inside of `wordpress/_data`. After importing, it will run a `local.sql` file that resets a few variables and resets the admin login to `admin:password` for ease of local dev. You can customize local.sql to make additional ovverides if you want that are project specific.
+## Managing WP deps with Composer
 
-## Updating Deps with Composer
+We tend to checkin our WP plugins to github if using a private repo. However for this open source repo, we don't. You'll want to remove those lines from the top of .gitignore inside the wordpress folder.
 
-To use, you must have composer running on your computer first. Afterwords you can
+If the plugins are not checked in, you'll need to install them with the VS Code task `Wordpress Composer Install`.
 
-- `Wordpress Composer Install` task will install Wordpress Deps.
-- Run the `Wordpress Composer Install` task to install Wordpress Deps.
-
-Setup Wordpress by going into the `wordpress` folder and running `composer install && yarn install`. Then you can use `yarn dev` as an alias to start docker. 2. Setup Next by going into the `website` folder and pulling down env variables by running `vercel env pull` (see 'configuring vercel' if first time). Then run `vercel dev` to preview the site locally.
+To update plugins, you can update their versions in the composer.json file, and then run the VS Code task `Wordpress Composer Update` task to install Wordpress Deps.
 
 ## New version of WordPresss
 
 When you want to update wordpress core, you need to update the `wordpress/docker-compose.yml` file for Docker users. Then run `Wordpress Docker Recreate` task to rebuild your local container.
 
 Also update `composer.json` so that non-docker users get the updated WP version.
+
+## WordPress DB
+
+If you want to pull down your DB from production to mirror locally, there is a DB import script that will run and import the latest version of a database file that exists inside of `wordpress/_data`. After importing, it will run a `local.sql` file that resets a few variables and resets the admin login to `admin:password` for ease of local dev. You can customize local.sql to make additional ovverides if you want that are project specific.
+
+This script can be run via the VS Code task `Wordpress DB Import`
+
+## Theme
+
+The `headless` theme is configured to make some light adjustments to WordPress to support headless dev.
+
+In `themes/headless/functions.php` there is a few variables that should be defined for each site.
+
+Additionally there is a theme option under the `Headless` menu where you can set the URL of your front-end. This variable is used to redirect the user whenever they try and access a page URL from WordPress admin, or should a user stumble on a url using your wordpress domain.
 
 ## WYSIWYG Editor
 

--- a/wordpress/.env.sample
+++ b/wordpress/.env.sample
@@ -1,0 +1,7 @@
+# COPY THIS FILE AND RENAME IT .ENV
+
+# This environment variable is automatically read by Docker and sets
+# the project name which is useful when starting new projects based
+# on this template. We also use this variable to set the wordpress database
+# name in docker-compose.yml and _build/db.sh
+COMPOSE_PROJECT_NAME=bubsnext

--- a/wordpress/_build/db.sh
+++ b/wordpress/_build/db.sh
@@ -1,10 +1,15 @@
 #!/bin/sh
 
+## env export, with unset at end of script
+if [ -f ".env" ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+
 WORDPRESS_DB_HOST="127.0.0.1"
 WORDPRESS_DB_PORT=3307
 WORDPRESS_DB_USER="root"
 WORDPRESS_DB_PASSWORD="somewordpress"
-WORDPRESS_DB_NAME="bubsnext"
+WORDPRESS_DB_NAME=${COMPOSE_PROJECT_NAME:-wordpress}
 
 ## Ideally these would work without having to hardcode above
 ## instead coming from docker ENV
@@ -13,21 +18,25 @@ echo $sql
 ext=${sql##*.}
 
 if [ $ext = "zip" ]; then
-    unzip -p $sql | mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME
+  unzip -p $sql | mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME
 elif [ $ext = "gz" ]; then
-    gunzip < $sql | mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME
+  gunzip < $sql | mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME
 else
-    mysql -u mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME < $sql
+  mysql -u mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME < $sql
 fi
 
 # run local mods if present
 file="_data/local.sql"
 if [ -f "$file" ]
 then
-    mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME < $file
-    echo "$file imported."
+  mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME < $file
+  echo "$file imported."
 else
-    echo "$file not found."
+  echo "$file not found."
+fi
+
+if [ -f ".env" ]; then
+  unset $(grep -v '^#' .env | sed -E 's/(.*)=.*/\1/' | xargs)
 fi
 
 echo 'import complete'

--- a/wordpress/_build/db.sh
+++ b/wordpress/_build/db.sh
@@ -9,7 +9,7 @@ WORDPRESS_DB_HOST="127.0.0.1"
 WORDPRESS_DB_PORT=3307
 WORDPRESS_DB_USER="root"
 WORDPRESS_DB_PASSWORD="somewordpress"
-WORDPRESS_DB_NAME=${COMPOSE_PROJECT_NAME:-wordpress}
+WORDPRESS_DB_NAME=${COMPOSE_PROJECT_NAME:-bubsnext}
 
 ## Ideally these would work without having to hardcode above
 ## instead coming from docker ENV

--- a/wordpress/docker-compose.yml
+++ b/wordpress/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: somewordpress
-      MYSQL_DATABASE: bubsnext
+      MYSQL_DATABASE: ${COMPOSE_PROJECT_NAME:-bubsnext}
       MYSQL_USER: wordpress
       MYSQL_PASSWORD: wordpress
 
@@ -27,7 +27,7 @@ services:
       WORDPRESS_DB_HOST: db:3306
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: somewordpress
-      WORDPRESS_DB_NAME: bubsnext
+      WORDPRESS_DB_NAME: ${COMPOSE_PROJECT_NAME:-bubsnext}
       WORDPRESS_DEBUG: 1
       WORDPRESS_CONFIG_EXTRA: |
         define('WP_ENV', 'development');


### PR DESCRIPTION
Pulls over code reviewed elsewhere to use a env file for WP DB naming.

Also updated docs to close #196 