### PR TITLE
Db export task, use env vars

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -24,9 +24,14 @@
       "command": "chmod -R 777 wordpress/wp-content/themes/headless/acf-json"
     },
     {
+      "label": "Wordpress DB Export",
+      "type": "shell",
+      "command": "cd wordpress && bash _build/db.sh export"
+    },
+    {
       "label": "Wordpress DB Import",
       "type": "shell",
-      "command": "cd wordpress && bash _build/db.sh"
+      "command": "cd wordpress && bash _build/db.sh import"
     },
     {
       "label": "Wordpress Dev",

--- a/wordpress/.env.sample
+++ b/wordpress/.env.sample
@@ -5,3 +5,6 @@
 # on this template. We also use this variable to set the wordpress database
 # name in docker-compose.yml and _build/db.sh
 COMPOSE_PROJECT_NAME=bubsnext
+COMPOSE_WPE_PRODUCTION=bubsnext
+COMPOSE_WPE_STAGING=bubsnexts
+COMPOSE_WPE_DEVELOPMENT=bubsnextd

--- a/wordpress/_build/db.sh
+++ b/wordpress/_build/db.sh
@@ -5,38 +5,60 @@ if [ -f ".env" ]; then
   export $(grep -v '^#' .env | xargs)
 fi
 
-WORDPRESS_DB_HOST="127.0.0.1"
-WORDPRESS_DB_PORT=3307
 WORDPRESS_DB_USER="root"
 WORDPRESS_DB_PASSWORD="somewordpress"
-WORDPRESS_DB_NAME=${COMPOSE_PROJECT_NAME:-bubsnext}
+WORDPRESS_DB_NAME=${COMPOSE_PROJECT_NAME:-wordpress}
+DB_CONTAINER="${COMPOSE_PROJECT_NAME:-wordpress}_db_1"
+PRODUCTION_SSH="${COMPOSE_WPE_PRODUCTION}@${COMPOSE_WPE_PRODUCTION}.ssh.wpengine.net"
 
-## Ideally these would work without having to hardcode above
-## instead coming from docker ENV
-sql=`ls -Art _data/* | tail -n 1`
-echo $sql
-ext=${sql##*.}
+function db_import() {
+  sql=`ls -Art _data/* | tail -n 1`
+  echo $sql
+  ext=${sql##*.}
 
-if [ $ext = "zip" ]; then
-  unzip -p $sql | mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME
-elif [ $ext = "gz" ]; then
-  gunzip < $sql | mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME
+  if [ $ext = "zip" ]; then
+    unzip -p $sql | docker exec -i $DB_CONTAINER mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -D $WORDPRESS_DB_NAME
+  elif [ $ext = "gz" ]; then
+    gunzip < $sql | docker exec -i $DB_CONTAINER mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -D $WORDPRESS_DB_NAME
+  else
+    docker exec -i $DB_CONTAINER mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -D $WORDPRESS_DB_NAME < $sql
+  fi
+
+  # run local mods if present
+  file="_data/local.sql"
+  if [ -f "$file" ]
+  then
+    docker exec -i $DB_CONTAINER mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -D $WORDPRESS_DB_NAME < $file
+    echo "$file imported."
+  else
+    echo "$file not found."
+  fi
+
+  if [ -f ".env" ]; then
+    unset $(grep -v '^#' .env | sed -E 's/(.*)=.*/\1/' | xargs)
+  fi
+
+  echo 'import complete'
+}
+
+function db_export() {
+  echo "$PRODUCTION_SSH";
+  wp db export --add-drop-table --ssh=$PRODUCTION_SSH - | gzip > _data/$(date +'%Y-%m-%d-%H-%M-%S').sql.gz
+  echo "export complete";
+}
+
+CALLED_FUNCTION=${1}
+
+if [ "$CALLED_FUNCTION" = "export" ]; then
+  echo "running DB export script"
+  db_export
+elif [ "$CALLED_FUNCTION" = "import" ]; then
+  echo "running DB import script"
+  db_import
 else
-  mysql -u mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME < $sql
-fi
-
-# run local mods if present
-file="_data/local.sql"
-if [ -f "$file" ]
-then
-  mysql -u $WORDPRESS_DB_USER -p$WORDPRESS_DB_PASSWORD -h $WORDPRESS_DB_HOST -P $WORDPRESS_DB_PORT $WORDPRESS_DB_NAME < $file
-  echo "$file imported."
-else
-  echo "$file not found."
+  error_exit "Specify a DB task (export or import)"
 fi
 
 if [ -f ".env" ]; then
   unset $(grep -v '^#' .env | sed -E 's/(.*)=.*/\1/' | xargs)
 fi
-
-echo 'import complete'

--- a/wordpress/_build/deploy.sh
+++ b/wordpress/_build/deploy.sh
@@ -1,9 +1,14 @@
-#!/bin/bash
+#!/bin/sh
 
 ## Per Project Variables -- CUSTOMIZE THESE FIRST
-PRODUCTION_REMOTE="git@git.wpengine.com:production/bubsnext.git"
-STAGING_REMOTE="git@git.wpengine.com:production/bubsnexts.git"
-DEVELOPMENT_REMOTE="git@git.wpengine.com:production/bubsnextd.git"
+
+## env export, with unset at end of script
+if [ -f ".env" ]; then
+  export $(grep -v '^#' .env | xargs)
+fi
+PRODUCTION_REMOTE="git@git.wpengine.com:production/${COMPOSE_WPE_PRODUCTION}.git"
+STAGING_REMOTE="git@git.wpengine.com:production/${COMPOSE_WPE_STAGING}.git"
+DEVELOPMENT_REMOTE="git@git.wpengine.com:production/${COMPOSE_WPE_DEVELOPMENT}.git"
 GIT_EMAIL="hello+bubs@patronage.org"
 GIT_NAME="Bubs Deploy"
 
@@ -93,8 +98,8 @@ else
     fi
 
     if [ `git branch --list deploy` ]; then
-        echo "Branch deploy already exists, deleting then continuing"
-        git branch -D deploy
+       echo "Branch deploy already exists, deleting then continuing"
+       git branch -D deploy
     fi
 
     # save current branch to a variable
@@ -158,4 +163,8 @@ else
     else
         error_exit "Something went wrong with the deploy."
     fi
+fi
+
+if [ -f ".env" ]; then
+  unset $(grep -v '^#' .env | sed -E 's/(.*)=.*/\1/' | xargs)
 fi


### PR DESCRIPTION
This PR does a few things to our DB  and deploy scripts

1) Use env variables, so we can keep them constant across projects
2) Adds an export script/task, which uses WP cli (must be installed locally) to ssh to production and export the db
3) For running import, no longer rely on local mysql, but uses the docker version
closes #213