### PR TITLE
fix: nodeByUri/graphcdn fix

### DIFF
--- a/website/src/lib/wordpress/index.js
+++ b/website/src/lib/wordpress/index.js
@@ -134,6 +134,26 @@ export async function getAllContentWithSlug(contentType) {
 }
 
 /**
+ * Determine if the given pathname is a contentnode before attempting to query for it
+ * @param {*} slug pathname from URL
+ * @returns
+ */
+export async function getNodeType(slug) {
+  const query = /* GraphQL */ `
+    query getNodeType($slug: String!) {
+      nodeByUri(uri: $slug) {
+        isContentNode
+        isTermNode
+      }
+    }
+  `;
+
+  const data = await fetchAPI(query, { variables: { slug } });
+
+  return data;
+}
+
+/**
  * Get fields for single page regardless of post type.
  */
 export async function getContent(slug, preview, previewData) {

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -92,10 +92,14 @@ export async function getStaticProps({
     return { redirect: redirect };
   }
 
-  // To reduce the amount of Stellate errors, don't try to query contentNode if the item isn't one
+  // Check nodeType before assuming it's a contentNode. We 404 on nonsupported types, but you could handle.
   const { nodeByUri } = await getNodeType(slug);
   if (!nodeByUri?.isContentNode) {
-    return { notFound: true };
+    return {
+      notFound: true,
+      revalidate: 60,
+      props: {},
+    };
   }
 
   const data = await getContent(slug, preview, previewData);

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -6,6 +6,7 @@ import checkRedirects from 'lib/checkRedirects';
 import { isStaticFile } from 'lib/utils';
 import {
   getContent,
+  getNodeType,
   getGlobalProps,
   getAllContentWithSlug,
 } from 'lib/wordpress';
@@ -89,6 +90,15 @@ export async function getStaticProps({
     redirect?.statusCode
   ) {
     return { redirect: redirect };
+  }
+
+  // To reduce the amount of Stellate errors, don't try to query contentNode if the item isn't one
+  const {
+    nodeByUri: { isContentNode },
+  } = await getNodeType(slug);
+
+  if (!isContentNode) {
+    return { notFound: true };
   }
 
   const data = await getContent(slug, preview, previewData);

--- a/website/src/pages/[[...slug]].js
+++ b/website/src/pages/[[...slug]].js
@@ -93,11 +93,8 @@ export async function getStaticProps({
   }
 
   // To reduce the amount of Stellate errors, don't try to query contentNode if the item isn't one
-  const {
-    nodeByUri: { isContentNode },
-  } = await getNodeType(slug);
-
-  if (!isContentNode) {
+  const { nodeByUri } = await getNodeType(slug);
+  if (!nodeByUri?.isContentNode) {
     return { notFound: true };
   }
 


### PR DESCRIPTION
This resolves a steady issue causing graphcdn to email us a generic error occurring across a variety of projects.

In #229 we narrowed down that issue to Wordpress supported but not bubs-next supported pathnames for taxonomies. To solve, this PR adds an additional check inside of getStaticContent which verifies that a pathname is actually a contentNode before we try querying contentNode for that path. The function can tell us whether a URL is a contentNode (which we always render), a termNode (we don't render) or neither (for example, a redirect or an actual 404).

This nice thing about this solve instead of hardrcoding a set of taxonomies which is going to change across different projects, we can actually check the source of truth on project taxonomies (which is Wordpress)

An example of this fix in practice:
In production, a 500 error: https://www.nextgenpolicy.org/category/advisory/
In the preview branch with this fix, a 404 http://nextgenpolicy-by91aal7d-patronage.vercel.app/category/advisory/

TODO:
* We still need some exceptions for `sitemap`, `feed`. 