### PR TITLE
404 check before trying to grab the current file

### DIFF
--- a/wordpress/wp-content/themes/headless/index.php
+++ b/wordpress/wp-content/themes/headless/index.php
@@ -13,7 +13,6 @@ if ( strpos($user_agent, 'WPEBot') ) {
   http_response_code(200);
   exit();
 }
-
 $redirect = headless_redirect();
 // echo $redirect;
 return wp_redirect( $redirect, 307 );

--- a/wordpress/wp-content/themes/headless/setup/helpers/headless-redirect.php
+++ b/wordpress/wp-content/themes/headless/setup/helpers/headless-redirect.php
@@ -19,7 +19,15 @@ function headless_redirect(){
   $id = get_queried_object_id();
   $url = get_permalink($id);
   $slug = parse_url($url, PHP_URL_PATH);
+  $path = $_SERVER['REQUEST_URI'];
   $redirect = '';
+
+  // if a 404 quickly fail and send to headless domain to handle
+  // if we don't, WP will return info on a post we don't want (e.g. the most recent post)
+  if (is_404()) {
+    $redirect = $headless_domain . $path;
+    return $redirect;
+  }
 
   // check if preview and user has edit ability.
   // if so, redirect to preview path


### PR DESCRIPTION
closes #244.

Before, we had this:

```
curl -I https://bubsnext.wpengine.com/foo
HTTP/2 307 
server: nginx
date: Thu, 09 Feb 2023 23:15:24 GMT
content-type: text/html; charset=UTF-8
content-length: 0
location: https://bubs-next-git-sitemaps-robots-patronage.vercel.app/posts/kitchen/
x-powered-by: WP Engine
link: <https://bubsnext.wpengine.com/wp-json/>; rel="https://api.w.org/"
expires: Wed, 11 Jan 1984 05:00:00 GMT
x-redirect-by: WordPress
x-cacheable: non200
cache-control: max-age=600, must-revalidate
x-cache: HIT: 1
x-cache-group: normal
x-orig-cache-control: no-cache, must-revalidate, max-age=0
```

Now (I deployed to live site for testing), we get this:

```
HTTP/2 307 
server: nginx
date: Thu, 09 Feb 2023 23:43:15 GMT
content-type: text/html; charset=UTF-8
content-length: 0
location: https://bubs-next-git-sitemaps-robots-patronage.vercel.app/foo
x-powered-by: WP Engine
link: <https://bubsnext.wpengine.com/wp-json/>; rel="https://api.w.org/"
expires: Wed, 11 Jan 1984 05:00:00 GMT
x-redirect-by: WordPress
x-cacheable: non200
cache-control: max-age=600, must-revalidate
x-cache: MISS
x-cache-group: normal
x-orig-cache-control: no-cache, must-revalidate, max-age=0
```