### PR TITLE
feat: default robots.txt for wordpress

### DIFF
--- a/wordpress/robots.txt
+++ b/wordpress/robots.txt
@@ -1,0 +1,4 @@
+# api server shouldn't be indexed, but images can be
+User-agent: *
+Allow: /wp-content/uploads/
+Disallow: /


### PR DESCRIPTION
We want to have a robots.txt that keeps headless origin out of indexes (while allowing images to be indexed).

closes #255 