### PR TITLE
fix: don't error if flex section isn't in graphql

### DIFF
--- a/website/src/components/flex/Flex.js
+++ b/website/src/components/flex/Flex.js
@@ -75,13 +75,13 @@ const Flex = ({ sections }) => {
     // uncomment if you need to debug graphql, but don't commit
     // console.log(section);
 
-    if (section.fieldGroupName.includes('Blockquote')) {
+    if (section.fieldGroupName?.includes('Blockquote')) {
       componentName = 'blockquote';
       component = <FlexBlockquote {...section} />;
-    } else if (section.fieldGroupName.includes('WysiwygContent')) {
+    } else if (section.fieldGroupName?.includes('WysiwygContent')) {
       componentName = 'wysiwyg';
       component = <FlexWysiwyg {...section} />;
-    } else if (section.fieldGroupName.includes('Hero')) {
+    } else if (section.fieldGroupName?.includes('Hero')) {
       componentName = 'hero';
       component = <FlexHero {...section} />;
     }


### PR DESCRIPTION
When creating new acf flex section, it might exist on site without having it in your graphql yet. When this happens, we won't get the fieldGroupName variable, but this shouldn't cause an error.