### PR TITLE
fix: exclude local.sql when calculating recent file to import

### DIFF
--- a/wordpress/_build/db.sh
+++ b/wordpress/_build/db.sh
@@ -39,7 +39,7 @@ function db_import() {
     echo "DB container '$DB_CONTAINER' detected; proceeding with import";
   fi
 
-  sql=`ls -Art _data/* | tail -n 1`
+  sql=$(ls -Art _data/* | grep -v "local.sql" | tail -n 1)
   echo $sql
   ext=${sql##*.}
 


### PR DESCRIPTION
Currently, if you:

1) Export a new db dump
2) Run import, DB dump then local.sql.

However if after you export, you then save local.sql with some change. When you go to import, it will think local.sql is the most recent file to import, and it'll import it twice.

This fixes that by calculating most recent as the last modified file not named local.sql.

closes #278 