### PR TITLE
fix: headless redirect duplicate code

### DIFF
--- a/wordpress/wp-content/themes/headless/setup/helpers/headless-redirect.php
+++ b/wordpress/wp-content/themes/headless/setup/helpers/headless-redirect.php
@@ -46,58 +46,5 @@ function headless_redirect() {
         $redirect = $headless_domain . $path;
     }
 
-    // if a 404 quickly fail and send to headless domain to handle
-    // if we don't, WP will return info on a post we don't want (e.g. the most recent post)
-    if (is_404()) {
-        $redirect = $headless_domain . $path;
-        return $redirect;
-    }
-
-    // check if preview and user has edit ability.
-    // if so, redirect to preview path
-    if (is_preview()) {
-        if (current_user_can('edit_posts')) {
-            $revisions = wp_get_post_revisions($id, [
-                'posts_per_page' => 1,
-                'fields' => 'ids',
-                'check_enabled' => false,
-            ]);
-
-            $auth_code = wpe_headless_generate_authentication_code(wp_get_current_user());
-
-            $preview_id = is_array($revisions) && !empty($revisions) ? array_values($revisions)[0] : null;
-
-            $redirect =
-                $headless_domain .
-                '/api/preview/?code=' .
-                rawurlencode($auth_code) .
-                '&id=' .
-                $id .
-                '&preview_id=' .
-                $preview_id;
-            return $redirect;
-        }
-    }
-
-    // else do standard redirect tree
-    if ($slug) {
-        if (current_user_can('edit_posts')) {
-            $auth_code = wpe_headless_generate_authentication_code(wp_get_current_user());
-            $redirect =
-                $headless_domain . '/api/preview/?code=' . rawurlencode($auth_code) . '&slug=' . $slug . '&id=' . $id;
-        } else {
-            $redirect = $headless_domain . $slug;
-        }
-    } else {
-        $path = $_SERVER['REQUEST_URI'];
-        if (current_user_can('edit_posts')) {
-            $auth_code = wpe_headless_generate_authentication_code(wp_get_current_user());
-            $redirect =
-                $headless_domain . '/api/preview/?code=' . rawurlencode($auth_code) . '&path=' . $path . '&id=' . $id;
-        } else {
-            $redirect = $headless_domain . $path;
-        }
-    }
-
     return $redirect;
 }


### PR DESCRIPTION
We still had our old headless redirect code in here below the new code, cleaning up with this small PR